### PR TITLE
chore(github): add repository governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,140 @@
+name: Bug report / 버그 신고
+description: Report a reproducible problem with ThruRNDIS. / 재현 가능한 문제를 신고합니다.
+title: "[Bug]: "
+labels:
+  - bug
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve ThruRNDIS.
+
+        Do not include WireGuard private keys, complete client configurations,
+        provisioning profiles, signing credentials, or other secrets. Report
+        vulnerabilities through [GitHub's private security advisory form](https://github.com/Afcoo/ThruRNDIS/security/advisories/new),
+        not through a public issue.
+
+        ThruRNDIS 개선에 도움을 주셔서 감사합니다. WireGuard 개인 키, 전체
+        클라이언트 설정, 프로비저닝 프로파일, 서명 자격 증명 등 비밀 정보는
+        첨부하지 마세요. 보안 취약점은 공개 Issue가 아닌 [GitHub 비공개 보안
+        신고 양식](https://github.com/Afcoo/ThruRNDIS/security/advisories/new)을
+        이용해 주세요.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area / 관련 영역
+      options:
+        - VM Asset installation or selection
+        - USB approval, detection, or passthrough
+        - VM boot or lifecycle
+        - WireGuard configuration or connection
+        - Network System Extension
+        - Onboarding, Settings, or menu bar
+        - Installation, signing, or distribution
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: ThruRNDIS version / ThruRNDIS 버전
+      description: Include the app version and build number when available.
+      placeholder: "0.2.1 (9)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: installation-method
+    attributes:
+      label: Installation method / 설치 방식
+      options:
+        - Release DMG
+        - Homebrew
+        - Local unsigned Xcode build
+        - Local signed Runtime build
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version / macOS 버전
+      description: Include the macOS version and build number.
+      placeholder: "macOS 27 beta (build ...)"
+    validations:
+      required: true
+
+  - type: input
+    id: mac-hardware
+    attributes:
+      label: Mac hardware / Mac 하드웨어
+      description: Include the Mac model and chip.
+      placeholder: "MacBook Pro, Apple M..."
+    validations:
+      required: true
+
+  - type: input
+    id: tethering-device
+    attributes:
+      label: Tethering device / 테더링 기기
+      description: Include the device model and OS version when the problem involves USB tethering.
+      placeholder: "Android device model, Android version, or Not applicable"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce / 재현 단계
+      description: Provide the shortest reliable sequence that reproduces the problem.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior / 기대 동작
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior / 실제 동작
+      description: Include exact error messages when possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics / 진단 정보
+      description: |
+        Attach exported app event logs or paste relevant serial-console excerpts.
+        Wrap pasted text in fenced code blocks when practical.
+        Redact private keys, complete WireGuard client configurations, signing
+        credentials, personal paths, and device identifiers.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context / 추가 정보
+      description: Add screenshots, timing details, or other information that may help.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation / 확인
+      options:
+        - label: I searched existing issues for the same problem. / 동일한 기존 Issue를 검색했습니다.
+          required: true
+        - label: I removed private keys, credentials, and other secrets. / 개인 키, 자격 증명 및 기타 비밀 정보를 제거했습니다.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation / 문서
+    url: https://thrurndis.afcoo.dev
+    about: Read the installation and troubleshooting documentation. / 설치 및 문제 해결 문서를 확인합니다.
+  - name: Questions and support / 질문 및 지원
+    url: https://github.com/Afcoo/ThruRNDIS/discussions
+    about: Ask usage and troubleshooting questions in GitHub Discussions. / 사용 및 문제 해결 질문은 GitHub Discussions에서 작성합니다.
+  - name: Private security report / 비공개 보안 신고
+    url: https://github.com/Afcoo/ThruRNDIS/security/advisories/new
+    about: Report suspected vulnerabilities privately. Do not open a public issue. / 의심되는 취약점은 공개 Issue가 아닌 비공개 경로로 신고합니다.
+  - name: VM Asset repository / VM Asset 저장소
+    url: https://github.com/Afcoo/ThruRNDIS_VM_Assets/issues
+    about: Report guest image, initramfs, kernel, or published VM Asset problems in the asset repository. / 게스트 이미지, initramfs, 커널 또는 배포된 VM Asset 문제를 신고합니다.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,80 @@
+name: Feature request / 기능 제안
+description: Propose an improvement grounded in a user need. / 사용자 문제를 해결하는 개선을 제안합니다.
+title: "[Feature]: "
+labels:
+  - enhancement
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the user problem before proposing an implementation.
+        Changes to the WireGuard-over-VZNAT data path, USB passthrough lifecycle,
+        key handling, signing model, or VM Asset boundary need explicit
+        architecture discussion.
+
+        구현 방법보다 사용자 문제를 먼저 설명해 주세요. WireGuard-over-VZNAT
+        데이터 경로, USB 패스스루 수명 주기, 키 처리, 서명 모델 또는 VM Asset
+        경계를 바꾸는 제안은 별도의 아키텍처 논의가 필요합니다.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area / 영역
+      options:
+        - VM Asset installation or selection
+        - USB approval, detection, or passthrough
+        - VM boot or lifecycle
+        - WireGuard configuration or connection
+        - Network System Extension
+        - Onboarding, Settings, or menu bar
+        - Logging or diagnostics
+        - Installation, signing, or distribution
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: User problem / 사용자 문제
+      description: Who is affected, and what are they unable to accomplish today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome / 원하는 결과
+      description: Describe observable behavior rather than internal implementation details.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered / 검토한 대안
+      description: Include current workarounds and why they are insufficient.
+
+  - type: textarea
+    id: architecture
+    attributes:
+      label: Architecture impact / 아키텍처 영향
+      description: |
+        Note any expected impact on USB passthrough, VM lifecycle, WireGuard,
+        Network System Extension, VM Assets, signing, security, or privacy.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context / 추가 정보
+      description: Add mockups, examples, links, or other supporting material.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation / 확인
+      options:
+        - label: I searched existing issues and discussions for similar requests. / 유사한 기존 Issue와 논의를 검색했습니다.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+## Summary
+
+<!-- What problem does this pull request solve, and why is this change needed? -->
+
+## Changes
+
+<!-- Describe the important behavior and implementation changes. -->
+
+## Related issue
+
+<!-- Use "Closes #123" when applicable. Small maintenance changes do not require an issue. -->
+
+## Validation
+
+<!-- Check every applicable item. Explain any item that is intentionally not applicable. -->
+
+- [ ] `./script/build_and_run.sh --verify`
+- [ ] Relevant XCTest coverage
+- [ ] Signed Runtime validation with `./script/build_and_install.sh`
+- [ ] Real USB/WireGuard validation
+- [ ] Not applicable; explanation:
+
+## User-facing impact
+
+<!-- Include screenshots for UI changes and note documentation or release-note impact. -->
+
+## Security and architecture
+
+<!-- Describe changes to USB, VM lifecycle, WireGuard, Network System Extension, VM Assets, signing, privacy, or key handling. Write "None" when there is no impact. -->
+
+## Checklist
+
+- [ ] The pull request has one focused purpose.
+- [ ] The title follows Conventional Commits, for example `fix(usb): serialize detach handling`.
+- [ ] Behavior changes include appropriate tests or an explanation of why automated testing is not practical.
+- [ ] User-facing behavior and operational changes are documented.
+- [ ] New, moved, renamed, or deleted Swift files are reflected in Xcode groups, target membership, and build phases.
+- [ ] No private keys, complete WireGuard client configurations, credentials, provisioning profiles, personal signing values, or local build artifacts are included.
+- [ ] Guest VM scripts and VM Asset build tooling remain in `Afcoo/ThruRNDIS_VM_Assets`.

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,50 @@
+name: PR policy
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-policy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  conventional-title:
+    name: Conventional PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Validate pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pattern='^(feat|fix|docs|refactor|test|build|ci|chore|perf|revert)(\([a-z0-9][a-z0-9-]*\))?!?: [^[:space:]].*$'
+
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            {
+              echo "Invalid pull request title: $PR_TITLE"
+              echo
+              echo "Use Conventional Commits syntax:"
+              echo "  type(optional-scope): concise description"
+              echo
+              echo "Allowed types:"
+              echo "  feat, fix, docs, refactor, test, build, ci, chore, perf, revert"
+              echo
+              echo "Examples:"
+              echo "  fix(usb): serialize detach handling"
+              echo "  feat!: change a public configuration format"
+              echo "  docs: clarify Runtime signing"
+            } >&2
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing to ThruRNDIS
+
+Thank you for helping improve ThruRNDIS. The project is a macOS 27+ menu-bar
+app that uses a WireGuard Network System Extension, a Virtualization framework
+Linux VM, and public AccessoryAccess USB passthrough APIs.
+
+Before making a substantial change, read [AGENTS.md](AGENTS.md). It documents
+the current architecture, ownership boundaries, build paths, signing
+requirements, and verification expectations.
+
+## Before opening an issue
+
+- Use the Bug Report form for a reproducible defect.
+- Use the Feature Request form to describe a user problem and desired outcome.
+- Use [GitHub Discussions](https://github.com/Afcoo/ThruRNDIS/discussions)
+  for installation, usage, or troubleshooting help.
+- Search existing issues before opening a new one.
+- Report guest kernel, initramfs, or published VM Asset problems in
+  [Afcoo/ThruRNDIS_VM_Assets](https://github.com/Afcoo/ThruRNDIS_VM_Assets/issues).
+- Report suspected security vulnerabilities privately according to
+  [SECURITY.md](SECURITY.md). Do not open a public issue.
+
+Never attach WireGuard private keys, complete client configurations,
+provisioning profiles, signing credentials, notary credentials, or other
+secrets. Redact personal paths and device identifiers from logs when they are
+not needed to reproduce a problem.
+
+## Architecture boundaries
+
+The supported data path is:
+
+```text
+ThruRNDIS WireGuardKit Network System Extension
+-> VZNAT guest endpoint
+-> guest WireGuard interface
+-> guest nftables masquerade
+-> USB RNDIS upstream
+```
+
+Changes that replace this path with an app-local packet relay, vmnet, bridged
+networking, or route-command UI are outside the current architecture. Propose
+an architecture change in an issue before implementing it.
+
+Keep these boundaries intact:
+
+- USB passthrough uses an AccessoryAccess `AAUSBAccessory` with the public
+  `VZUSBPassthroughDeviceConfiguration(device:)` API.
+- The app does not inspect or relay packet payloads.
+- Client private keys are not persisted in tunnel-provider configuration or
+  shared with the guest.
+- Guest VM scripts, dependency locking, and VM Asset release tooling belong in
+  `Afcoo/ThruRNDIS_VM_Assets`, not this repository.
+- Personal signing values and `Configuration/LocalSigning.xcconfig` must not be
+  committed.
+
+## Development setup
+
+Use Xcode beta and the project-local unsigned workflow for normal development:
+
+```sh
+./script/build_and_run.sh
+```
+
+The normal minimum verification after a code change is:
+
+```sh
+./script/build_and_run.sh --verify
+```
+
+Run relevant XCTest coverage for the code you change. Real USB passthrough,
+Virtualization, Network System Extension activation, and WireGuard runtime
+validation require the signed Runtime build, approved entitlements, and
+appropriate hardware:
+
+```sh
+./script/build_and_install.sh
+```
+
+Do not treat unavailable signing as a blocker for compile, UI, documentation,
+or unit-test work. Clearly state which checks were run and which runtime paths
+were not verified.
+
+The full Developer ID, notarization, and DMG workflow is required only for a
+public release:
+
+```sh
+./script/package_app.sh
+```
+
+## Code organization
+
+Follow the layer ownership and Swift naming conventions in `AGENTS.md`.
+Observable UI state belongs in stores, long-running workflows in coordinators,
+external operations in services, and stateless transformations in focused
+helpers.
+
+The Xcode project uses explicit groups. When adding, moving, renaming, or
+deleting Swift files, update the matching Xcode group, target membership, and
+build phase.
+
+## Commits and pull requests
+
+Keep each pull request focused on one concern. Small documentation and
+maintenance pull requests do not need a separate issue; behavior changes and
+larger designs should link one with `Closes #123` when applicable.
+
+Pull request titles use Conventional Commits syntax:
+
+```text
+feat(wireguard): validate endpoint overrides
+fix(usb): serialize detach handling
+docs: clarify Runtime signing
+```
+
+Allowed types are `feat`, `fix`, `docs`, `refactor`, `test`, `build`, `ci`,
+`chore`, `perf`, and `revert`. Use a short lowercase scope when it adds useful
+context. Add `!` before the colon for an intentional breaking change.
+
+Complete the pull request template, describe architecture and security impact,
+and include:
+
+- tests and commands that were run;
+- untested runtime paths and the reason they were not tested;
+- screenshots for visible UI changes;
+- documentation updates for user-facing or operational changes.
+
+The intended merge strategy is squash merge so that the validated pull request
+title becomes the commit on `main`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+ThruRNDIS handles USB passthrough, a privileged macOS Network System Extension,
+a Virtualization framework VM, and WireGuard private keys. Please report
+suspected vulnerabilities privately and avoid exposing sensitive material in a
+public issue.
+
+## Supported versions
+
+Security fixes are developed for the latest published release and the current
+`main` branch. Older releases may be asked to upgrade before a report is
+investigated or fixed.
+
+## Reporting a vulnerability
+
+Use GitHub's private
+[security advisory form](https://github.com/Afcoo/ThruRNDIS/security/advisories/new).
+Do not open a public issue for a suspected vulnerability.
+
+Include only the information needed to reproduce and assess the report:
+
+- affected ThruRNDIS version and build;
+- macOS version and hardware;
+- affected component and security impact;
+- reproducible steps or a minimal proof of concept;
+- whether exploitation requires USB access, user approval, signing, or an
+  installed System Extension;
+- suggested mitigations, if known.
+
+Do not submit real WireGuard private keys, complete client configurations,
+Apple signing credentials, notary credentials, provisioning profiles, or
+unrelated personal data. Replace secrets with clearly marked test values.
+
+Reports involving the published guest kernel, initramfs, or VM Asset release
+pipeline should be submitted privately to
+[Afcoo/ThruRNDIS_VM_Assets](https://github.com/Afcoo/ThruRNDIS_VM_Assets/security)
+when that repository is the affected component.
+
+The maintainer will make a best effort to acknowledge a complete report within
+seven days, assess its scope, and coordinate remediation and disclosure.
+Please allow reasonable time for a fix before publishing details.
+
+## Security-sensitive areas
+
+Reports are especially useful when they involve:
+
+- WireGuard private-key generation, storage, sharing, or tunnel startup;
+- Network System Extension activation or provider configuration;
+- USB AccessoryAccess approval and passthrough lifecycle;
+- VM Asset download, checksum validation, archive extraction, or promotion;
+- signing, entitlements, notarization, release artifacts, or update metadata;
+- unintended packet routing, privilege escalation, sandbox escape, or secret
+  disclosure.
+
+General bugs without a security impact should use the public Bug Report form.


### PR DESCRIPTION
## Summary

- add bilingual bug and feature Issue Forms with guided diagnostics and security reporting
- disable blank issues and route support, security, and VM Asset requests to the appropriate channels
- add a pull request template and Conventional Commits title validation workflow
- document contribution, architecture, validation, and vulnerability-reporting policies

## Why

The repository now requires pull requests for changes to `main`, but it did not yet provide contributor-facing Issue/PR guidance or a lightweight automated policy check. These files establish the initial governance workflow while keeping macOS 27 runtime verification manual until suitable CI is available.

## Validation

- parsed all GitHub YAML files with Ruby YAML
- validated Issue Form structure and unique field IDs
- exercised accepted and rejected Conventional PR title cases
- ran staged diff whitespace checks
- reviewed all governance files after enabling private vulnerability reporting for both app and VM Asset repositories

## Impact

No application source, signing configuration, VM assets, or runtime behavior is changed. The new templates and workflow take effect after this pull request is merged into `main`.