### PR TITLE
feat(ui): refresh onboarding and settings window chrome

### DIFF
--- a/ThruRNDIS/Presentation/OnboardingWindowController.swift
+++ b/ThruRNDIS/Presentation/OnboardingWindowController.swift
@@ -137,8 +137,16 @@ final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
         )
         let window = NSWindow(contentViewController: hostingController)
 
-        window.title = String(localized: "Welcome to ThruRNDIS")
-        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.title = "ThruRNDIS"
+        window.styleMask = [
+            .titled,
+            .closable,
+            .miniaturizable,
+            .fullSizeContentView,
+        ]
+        window.titlebarAppearsTransparent = true
+        window.titlebarSeparatorStyle = .none
+        window.isMovableByWindowBackground = true
         resizeBridge.window = window
         resizeBridge.preferredContentSizeProvider = { [weak hostingController] in
             guard let hostingController else {

--- a/ThruRNDIS/Presentation/SettingsWindowController.swift
+++ b/ThruRNDIS/Presentation/SettingsWindowController.swift
@@ -41,7 +41,18 @@ final class SettingsWindowController: NSWindowController {
         let window = NSWindow(contentViewController: hostingController)
 
         window.title = String(localized: "ThruRNDIS Settings")
-        window.styleMask = [.titled, .closable]
+        window.styleMask = [
+            .titled,
+            .closable,
+            .miniaturizable,
+            .resizable,
+            .fullSizeContentView,
+        ]
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.titlebarSeparatorStyle = .none
+        window.toolbarStyle = .unified
+        window.isMovableByWindowBackground = true
         window.setContentSize(NSSize(width: 800, height: 520))
         window.isReleasedWhenClosed = false
         window.isRestorable = false

--- a/ThruRNDIS/Presentation/SettingsWindowController.swift
+++ b/ThruRNDIS/Presentation/SettingsWindowController.swift
@@ -53,7 +53,7 @@ final class SettingsWindowController: NSWindowController {
         window.titlebarSeparatorStyle = .none
         window.toolbarStyle = .unified
         window.isMovableByWindowBackground = true
-        window.setContentSize(NSSize(width: 800, height: 520))
+        window.setContentSize(NSSize(width: 760, height: 480))
         window.isReleasedWhenClosed = false
         window.isRestorable = false
         window.center()

--- a/ThruRNDIS/Views/OnboardingView.swift
+++ b/ThruRNDIS/Views/OnboardingView.swift
@@ -35,16 +35,6 @@ struct OnboardingView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 8) {
-                ForEach(0..<4, id: \.self) { index in
-                    Capsule()
-                        .fill(index <= step ? Color.accentColor : Color.secondary.opacity(0.2))
-                        .frame(height: 4)
-                }
-            }
-            .padding(.horizontal, 32)
-            .padding(.top, 12)
-
             ViewThatFits(in: .vertical) {
                 stepContent
                     .fixedSize(horizontal: false, vertical: true)
@@ -55,37 +45,70 @@ struct OnboardingView: View {
             }
             .frame(maxWidth: .infinity)
 
-            Divider()
-
-            HStack {
-                if step > 0 {
-                    Button("Back") {
-                        step -= 1
-                    }
-                }
-
-                Spacer()
-
-                if step < 3 {
-                    Button("Continue") {
-                        step += 1
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!canContinue)
-                } else {
-                    Button("Finish") {
-                        store.completeOnboarding()
-                        if assetWorkflowCoordinator.hasConfiguredAssets {
-                            onFinish()
+            ZStack {
+                HStack {
+                    if step > 0 {
+                        Button {
+                            step -= 1
+                        } label: {
+                            Label("Back", systemImage: "chevron.backward")
+                                .labelStyle(.titleAndIcon)
                         }
+                        .buttonStyle(.glass)
+                        .controlSize(.extraLarge)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!assetWorkflowCoordinator.hasConfiguredAssets || assetWorkflowCoordinator.isBusy)
+
+                    Spacer()
+
+                    if step < 3 {
+                        Button("Continue") {
+                            step += 1
+                        }
+                        .buttonStyle(.glassProminent)
+                        .controlSize(.extraLarge)
+                        .tint(.accentColor)
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(!canContinue)
+                    } else {
+                        Button {
+                            store.completeOnboarding()
+                            if assetWorkflowCoordinator.hasConfiguredAssets {
+                                onFinish()
+                            }
+                        } label: {
+                            Label("Finish", systemImage: "checkmark")
+                                .labelStyle(.titleAndIcon)
+                        }
+                        .buttonStyle(.glassProminent)
+                        .controlSize(.extraLarge)
+                        .tint(.accentColor)
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(
+                            !assetWorkflowCoordinator.hasConfiguredAssets
+                                || assetWorkflowCoordinator.isBusy
+                        )
+                    }
                 }
+
+                HStack(spacing: 8) {
+                    ForEach(0..<4, id: \.self) { index in
+                        Image(systemName: "circle.fill")
+                            .font(.system(size: 6))
+                            .foregroundStyle(
+                                index == step
+                                    ? Color.accentColor
+                                    : Color.secondary.opacity(0.35)
+                            )
+                    }
+                }
+                .accessibilityHidden(true)
             }
-            .padding(12)
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 16)
         }
         .frame(width: contentWidth)
+        .containerBackground(.thickMaterial, for: .window)
         .onReceive(assetWorkflowCoordinator.$errorMessage.compactMap { $0 }) { message in
             alert = OnboardingAlert(message: message)
         }

--- a/ThruRNDIS/Views/Settings/SettingsView.swift
+++ b/ThruRNDIS/Views/Settings/SettingsView.swift
@@ -41,10 +41,12 @@ struct SettingsView: View {
                     InfoView(resetAndRestart: resetAndRestart)
                 }
             }
-            .scenePadding()
+            .navigationTitle(selectedSection.title)
+            .scrollEdgeEffectHidden(true, for: .top)
         }
         .formStyle(.grouped)
-        .frame(width: 800, height: 520)
+        .frame(minWidth: 800, minHeight: 520)
+        .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
         .onAppear {
             appPreferences.refreshLaunchAtLoginStatus()
         }

--- a/ThruRNDIS/Views/Settings/SettingsView.swift
+++ b/ThruRNDIS/Views/Settings/SettingsView.swift
@@ -21,7 +21,7 @@ struct SettingsView: View {
                     .tag(section)
             }
             .listStyle(.sidebar)
-            .navigationSplitViewColumnWidth(min: 170, ideal: 190, max: 220)
+            .navigationSplitViewColumnWidth(min: 170, ideal: 170, max: 170)
         } detail: {
             Group {
                 switch selectedSection {
@@ -45,7 +45,7 @@ struct SettingsView: View {
             .scrollEdgeEffectHidden(true, for: .top)
         }
         .formStyle(.grouped)
-        .frame(minWidth: 800, minHeight: 520)
+        .frame(minWidth: 760, minHeight: 480)
         .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
         .onAppear {
             appPreferences.refreshLaunchAtLoginStatus()

--- a/ThruRNDIS/Views/Settings/WireGuardView.swift
+++ b/ThruRNDIS/Views/Settings/WireGuardView.swift
@@ -144,20 +144,17 @@ struct WireGuardView: View {
             }
 
             Section("Host Configuration (Debug / Export)") {
-                ScrollView([.horizontal, .vertical]) {
-                    Text(verbatim: wireGuardSession.clientConfiguration)
-                        .font(.system(.body, design: .monospaced))
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: true, vertical: false)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(8)
+                GroupBox {
+                    ScrollView([.horizontal, .vertical]) {
+                        Text(verbatim: wireGuardSession.clientConfiguration)
+                            .font(.system(.body, design: .monospaced))
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(8)
+                    }
                 }
                 .frame(height: 260)
-                .background(.quaternary.opacity(0.2))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 5)
-                        .stroke(.quaternary)
-                }
 
                 HStack {
                     Button("Copy") {

--- a/ThruRNDIS/Views/SharedViews/LogTextView.swift
+++ b/ThruRNDIS/Views/SharedViews/LogTextView.swift
@@ -8,16 +8,14 @@ struct LogTextView: View {
     let text: String
 
     var body: some View {
-        ScrollView {
-            Text(verbatim: text)
-                .font(.system(.caption, design: .monospaced))
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(8)
+        GroupBox {
+            ScrollView {
+                Text(verbatim: text)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+            }
         }
-        .background(
-            .quaternary.opacity(0.35),
-            in: RoundedRectangle(cornerRadius: 6)
-        )
     }
 }


### PR DESCRIPTION
## Summary

- refresh the onboarding window with an integrated title bar, bottom Liquid Glass navigation controls, and four-dot page progress
- adopt a unified system sidebar and transparent title bar for Settings
- use native grouped containers for log and WireGuard configuration content
- fix the Settings sidebar at 170 pt and set the window’s initial/minimum content size to 760 × 480 pt

## Why

The onboarding and Settings windows used older, visually separated chrome that did not match the current macOS Liquid Glass presentation. The Settings detail scroll area also had custom toolbar and padding behavior that prevented the title bar and sidebar from appearing fully integrated.

## Impact

The underlying setup, VM, USB, WireGuard, and logging behavior is unchanged. This PR only updates window presentation and layout using SwiftUI and AppKit system components.

## Validation

- `xcodebuild -project ThruRNDIS.xcodeproj -scheme ThruRNDIS -configuration Debug -destination platform=macOS -derivedDataPath /tmp/ThruRNDIS-DerivedData CODE_SIGNING_ALLOWED=NO test`
- 115 tests passed, 0 failed