### PR TITLE
fix(app): activate helper update alert

### DIFF
--- a/ThruRNDIS/App/App.swift
+++ b/ThruRNDIS/App/App.swift
@@ -298,7 +298,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = String(
@@ -310,6 +309,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.addButton(withTitle: String(localized: "Update"))
         alert.addButton(withTitle: String(localized: "Not Now"))
 
+        RunLoop.main.perform(inModes: [.modalPanel]) {
+            NSApp.activate(ignoringOtherApps: true)
+        }
         guard alert.runModal() == .alertFirstButtonReturn else {
             eventLog.append(
                 "Dummy Ethernet helper update deferred at app launch.",


### PR DESCRIPTION
## What changed

- Schedule application activation in the modal-panel run loop before presenting the startup helper update alert.
- Keep `NSAlert.runModal()` responsible for the alert's native positioning and presentation animation.

## Why

The startup helper update alert could appear while ThruRNDIS was inactive, leaving its default **Update** button without the accent highlight. Scheduling activation with `DispatchQueue.main.async` did not run while the alert's modal-panel event loop was active.

## Impact

The startup reinstall prompt becomes active and shows the default button highlight without forcing the alert window forward or bypassing its standard animation.

## Validation

- `xcodebuild -project ThruRNDIS.xcodeproj -scheme ThruRNDIS -configuration Debug -destination platform=macOS -derivedDataPath /tmp/ThruRNDIS-DerivedData CODE_SIGNING_ALLOWED=NO build`
- `git diff --check origin/main...HEAD`