### PR TITLE
fix(app): prevent termination hangs on helper failures

### DIFF
--- a/ThruRNDIS/App/App.swift
+++ b/ThruRNDIS/App/App.swift
@@ -103,12 +103,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var onboardingWindowController: OnboardingWindowController?
     private var onboardingPresentationID: UUID?
     private var cancellables: Set<AnyCancellable> = []
-    private var pendingTerminationApplication: NSApplication?
-    private var pendingResetTerminationApplication: NSApplication?
-    private var didPrepareForTermination = false
-    private var storeTerminationTask: Task<Void, Never>?
-    private var eventLogTerminationTask: Task<Void, Never>?
-    private var resetAndRestartTask: Task<Void, Never>?
+    private var isTerminating = false
+    private var isResettingAndRestarting = false
     private let applicationRelaunchService = ApplicationRelaunchService()
     private var isPreparedForResetRelaunchTermination = false
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -188,8 +184,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let self else {
                     return
                 }
-                guard self.pendingTerminationApplication == nil else {
-                    self.finishPendingTerminationIfPossible()
+                guard !self.isTerminating else {
                     return
                 }
                 self.store.assetAvailabilityDidChange()
@@ -224,11 +219,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return .terminateNow
         }
 
-        if resetAndRestartTask != nil {
-            guard pendingResetTerminationApplication == nil else {
+        if isResettingAndRestarting {
+            guard !isTerminating else {
                 return .terminateLater
             }
-            pendingResetTerminationApplication = sender
+            isTerminating = true
             eventLog.append(
                 "Application termination will wait for the settings reset workflow.",
                 level: .debug,
@@ -237,7 +232,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return .terminateLater
         }
 
-        guard pendingTerminationApplication == nil else {
+        guard !isTerminating else {
             return .terminateLater
         }
 
@@ -250,9 +245,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return .terminateCancel
         }
 
-        pendingTerminationApplication = sender
-        prepareForTerminationIfNeeded()
-        finishPendingTerminationIfPossible()
+        isTerminating = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.prepareApplicationServicesForTermination()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
         return .terminateLater
     }
 
@@ -325,20 +323,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func resetAppSettingsAndRestart() {
-        guard resetAndRestartTask == nil,
-              pendingTerminationApplication == nil,
-              pendingResetTerminationApplication == nil,
-              !didPrepareForTermination else {
+        guard !isResettingAndRestarting,
+              !isTerminating else {
             return
         }
 
-        resetAndRestartTask = Task { @MainActor [weak self] in
+        isResettingAndRestarting = true
+        Task { @MainActor [weak self] in
             guard let self else {
                 return
             }
             guard await self.store.resetAppSettings() else {
-                self.resetAndRestartTask = nil
-                self.cancelPendingTerminationDuringReset()
+                self.finishFailedReset()
                 self.presentResetFailure()
                 return
             }
@@ -355,8 +351,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     level: .error,
                     category: .application
                 )
-                self.resetAndRestartTask = nil
-                self.cancelPendingTerminationDuringReset()
+                self.finishFailedReset()
                 self.presentRestartFailure(error)
                 return
             }
@@ -366,29 +361,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 category: .application
             )
 
-            self.assetWorkflowCoordinator.prepareForApplicationTermination()
-            await self.store.prepareForApplicationTermination(
-                disconnectWireGuard: false
-            )
-            await self.eventLog.prepareForApplicationTermination()
-            self.didPrepareForTermination = true
+            await self.prepareApplicationServicesForTermination()
             self.isPreparedForResetRelaunchTermination = true
-            self.resetAndRestartTask = nil
-            if let application = self.pendingResetTerminationApplication {
-                self.pendingResetTerminationApplication = nil
-                application.reply(toApplicationShouldTerminate: true)
+            self.isResettingAndRestarting = false
+            if self.isTerminating {
+                NSApp.reply(toApplicationShouldTerminate: true)
             } else {
                 NSApp.terminate(nil)
             }
         }
     }
 
-    private func cancelPendingTerminationDuringReset() {
-        guard let application = pendingResetTerminationApplication else {
-            return
-        }
-        pendingResetTerminationApplication = nil
-        application.reply(toApplicationShouldTerminate: false)
+    private func finishFailedReset() {
+        isResettingAndRestarting = false
+        guard isTerminating else { return }
+        isTerminating = false
+        NSApp.reply(toApplicationShouldTerminate: false)
     }
 
     private func presentResetFailure(_ message: String? = nil) {
@@ -473,49 +461,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return alert.runModal() == .alertFirstButtonReturn
     }
 
-    private func prepareForTerminationIfNeeded() {
-        guard !didPrepareForTermination else {
-            return
-        }
-        didPrepareForTermination = true
+    private func prepareApplicationServicesForTermination() async {
         eventLog.append(
             "Preparing application services for termination.",
             level: .debug,
             category: .application
         )
-        assetWorkflowCoordinator.prepareForApplicationTermination()
-        storeTerminationTask = Task { @MainActor [weak self] in
-            guard let self else {
-                return
-            }
-            await self.store.prepareForApplicationTermination()
-            self.storeTerminationTask = nil
-            self.finishPendingTerminationIfPossible()
-        }
-    }
-
-    private func finishPendingTerminationIfPossible() {
-        guard let application = pendingTerminationApplication,
-              !assetWorkflowCoordinator.isBusy,
-              storeTerminationTask == nil else {
-            return
-        }
-        guard eventLogTerminationTask == nil else {
-            return
-        }
-
-        eventLogTerminationTask = Task { @MainActor [weak self] in
-            guard let self else {
-                return
-            }
-            await self.eventLog.prepareForApplicationTermination()
-            guard self.pendingTerminationApplication === application else {
-                self.eventLogTerminationTask = nil
-                return
-            }
-            self.eventLogTerminationTask = nil
-            self.pendingTerminationApplication = nil
-            application.reply(toApplicationShouldTerminate: true)
-        }
+        async let assetTermination: Void = assetWorkflowCoordinator
+            .prepareForApplicationTermination()
+        await store.prepareForApplicationTermination()
+        await assetTermination
+        await eventLog.prepareForApplicationTermination()
     }
 }

--- a/ThruRNDIS/Coordinators/VMAssetWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/VMAssetWorkflowCoordinator.swift
@@ -260,8 +260,10 @@ final class VMAssetWorkflowCoordinator: ObservableObject, VMAssetProviding {
         installState = currentSelection.map { .ready(message: readyMessage(for: $0)) } ?? .idle
     }
 
-    func prepareForApplicationTermination() {
-        operationTask?.cancel()
+    func prepareForApplicationTermination() async {
+        let task = operationTask
+        task?.cancel()
+        await task?.value
     }
 
     private func runLatestInstall(operationID: UUID) async {

--- a/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
+++ b/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
@@ -41,8 +41,16 @@ enum DummyEthernetPrivilegedHelperClientError: Error, Equatable, LocalizedError 
 
 @MainActor
 final class DummyEthernetPrivilegedHelperClient {
+    private static let statusRequestTimeout: DispatchTimeInterval = .seconds(10)
+    // A normal start may spend 3 seconds waiting for its Bond and another
+    // 12 seconds waiting for the wired network path before replying.
+    private static let startRequestTimeout: DispatchTimeInterval = .seconds(20)
+    private static let stopRequestTimeout: DispatchTimeInterval = .seconds(10)
+
     func status() async throws -> DummyEthernetNetworkSnapshot {
-        try await sendRequest { proxy, reply in
+        try await sendRequest(
+            timeout: Self.statusRequestTimeout
+        ) { proxy, reply in
             proxy.status(withReply: reply)
         }
     }
@@ -50,18 +58,30 @@ final class DummyEthernetPrivilegedHelperClient {
     func start(
         configuration: DummyEthernetConfiguration
     ) async throws -> DummyEthernetNetworkSnapshot {
-        try await sendRequest { proxy, reply in
-            proxy.start(
-                hostIPv4Address: configuration.hostIPv4Address,
-                memberInterfaceName: configuration.memberInterfaceName,
-                peerInterfaceName: configuration.peerInterfaceName,
-                withReply: reply
-            )
+        do {
+            return try await sendRequest(
+                timeout: Self.startRequestTimeout
+            ) { proxy, reply in
+                proxy.start(
+                    hostIPv4Address: configuration.hostIPv4Address,
+                    memberInterfaceName: configuration.memberInterfaceName,
+                    peerInterfaceName: configuration.peerInterfaceName,
+                    withReply: reply
+                )
+            }
+        } catch let error as DummyEthernetPrivilegedHelperClientError
+            where error == .requestTimedOut {
+            // The helper may still finish a queued Start after the client timeout.
+            // Queue a bounded Stop so that late completion cannot leave it active.
+            _ = try? await stop()
+            throw error
         }
     }
 
     func stop() async throws -> DummyEthernetNetworkSnapshot {
-        try await sendRequest { proxy, reply in
+        try await sendRequest(
+            timeout: Self.stopRequestTimeout
+        ) { proxy, reply in
             proxy.stop(withReply: reply)
         }
     }
@@ -80,6 +100,7 @@ final class DummyEthernetPrivilegedHelperClient {
     }
 
     private func sendRequest(
+        timeout requestTimeout: DispatchTimeInterval,
         _ request: @escaping (
             DummyEthernetPrivilegedHelperProtocol,
             @escaping DummyEthernetPrivilegedHelperReply
@@ -92,6 +113,18 @@ final class DummyEthernetPrivilegedHelperClient {
                 connection: connection,
                 continuation: continuation
             )
+            connection.interruptionHandler = {
+                reply.resume(with: .failure(
+                    DummyEthernetPrivilegedHelperClientError
+                        .remoteObjectUnavailable(message: nil)
+                ))
+            }
+            connection.invalidationHandler = {
+                reply.resume(with: .failure(
+                    DummyEthernetPrivilegedHelperClientError
+                        .remoteObjectUnavailable(message: nil)
+                ))
+            }
             connection.activate()
 
             let remoteObject = connection.remoteObjectProxyWithErrorHandler {
@@ -127,8 +160,9 @@ final class DummyEthernetPrivilegedHelperClient {
                     ))
                 }
             }
-            DispatchQueue.global().asyncAfter(deadline: .now() + 60) {
-                [weak reply] in
+            DispatchQueue.global().asyncAfter(
+                deadline: .now() + requestTimeout
+            ) { [weak reply] in
                 reply?.resume(with: .failure(
                     DummyEthernetPrivilegedHelperClientError.requestTimedOut
                 ))

--- a/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
+++ b/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
@@ -79,9 +79,17 @@ final class DummyEthernetPrivilegedHelperClient {
     }
 
     func stop() async throws -> DummyEthernetNetworkSnapshot {
-        try await sendRequest(
-            timeout: Self.stopRequestTimeout
-        ) { proxy, reply in
+        try await stop(timeout: Self.stopRequestTimeout)
+    }
+
+    func stopAndWaitUntilFinished() async throws -> DummyEthernetNetworkSnapshot {
+        try await stop(timeout: nil)
+    }
+
+    private func stop(
+        timeout: DispatchTimeInterval?
+    ) async throws -> DummyEthernetNetworkSnapshot {
+        try await sendRequest(timeout: timeout) { proxy, reply in
             proxy.stop(withReply: reply)
         }
     }
@@ -100,7 +108,7 @@ final class DummyEthernetPrivilegedHelperClient {
     }
 
     private func sendRequest(
-        timeout requestTimeout: DispatchTimeInterval,
+        timeout requestTimeout: DispatchTimeInterval?,
         _ request: @escaping (
             DummyEthernetPrivilegedHelperProtocol,
             @escaping DummyEthernetPrivilegedHelperReply
@@ -160,12 +168,14 @@ final class DummyEthernetPrivilegedHelperClient {
                     ))
                 }
             }
-            DispatchQueue.global().asyncAfter(
-                deadline: .now() + requestTimeout
-            ) { [weak reply] in
-                reply?.resume(with: .failure(
-                    DummyEthernetPrivilegedHelperClientError.requestTimedOut
-                ))
+            if let requestTimeout {
+                DispatchQueue.global().asyncAfter(
+                    deadline: .now() + requestTimeout
+                ) { [weak reply] in
+                    reply?.resume(with: .failure(
+                        DummyEthernetPrivilegedHelperClientError.requestTimedOut
+                    ))
+                }
             }
         }
         return try Self.decodeSnapshot(from: data)

--- a/ThruRNDIS/Stores/DummyEthernetStore.swift
+++ b/ThruRNDIS/Stores/DummyEthernetStore.swift
@@ -298,7 +298,7 @@ final class DummyEthernetStore: ObservableObject {
         defer { operation = nil }
 
         do {
-            let snapshot = try await networkManager.stop()
+            let snapshot = try await networkManager.stopAndWaitUntilFinished()
             applySnapshot(snapshot)
             appendCompletionEvent(for: .stopping, snapshot: snapshot)
             guard snapshot.state == .inactive else {

--- a/ThruRNDIS/Stores/DummyEthernetStore.swift
+++ b/ThruRNDIS/Stores/DummyEthernetStore.swift
@@ -253,7 +253,8 @@ final class DummyEthernetStore: ObservableObject {
         }
 
         return await stopManagedConfiguration(
-            requestMessage: "Dummy Ethernet stop requested."
+            requestMessage: "Dummy Ethernet stop requested.",
+            stopRequest: networkManager.stop
         )
     }
 
@@ -280,12 +281,15 @@ final class DummyEthernetStore: ObservableObject {
         }
 
         return await stopManagedConfiguration(
-            requestMessage: "Dummy Ethernet stop requested for application termination."
+            requestMessage: "Dummy Ethernet stop requested for application termination.",
+            stopRequest: networkManager.stopAndWaitUntilFinished
         )
     }
 
     private func stopManagedConfiguration(
-        requestMessage: String
+        requestMessage: String,
+        stopRequest: @MainActor () async throws
+            -> DummyEthernetNetworkSnapshot
     ) async -> Bool {
         helper.refresh()
         guard helper.isAvailable else {
@@ -298,7 +302,7 @@ final class DummyEthernetStore: ObservableObject {
         defer { operation = nil }
 
         do {
-            let snapshot = try await networkManager.stopAndWaitUntilFinished()
+            let snapshot = try await stopRequest()
             applySnapshot(snapshot)
             appendCompletionEvent(for: .stopping, snapshot: snapshot)
             guard snapshot.state == .inactive else {

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -791,9 +791,7 @@ final class TetheringStore: ObservableObject {
         )
     }
 
-    func prepareForApplicationTermination(
-        disconnectWireGuard: Bool = true
-    ) async {
+    func prepareForApplicationTermination() async {
         guard applicationState != .terminating else { return }
         applicationState = .terminating
         shouldRunAccessoryMonitoring = false
@@ -805,20 +803,14 @@ final class TetheringStore: ObservableObject {
         workflowCoordinator.cancelPendingWireGuardConnection(
             reason: "application termination"
         )
-        await wireGuardSession.prepareForApplicationTermination(
-            disconnectTunnel: disconnectWireGuard
-        )
+        await wireGuardSession.prepareForApplicationTermination()
         if let managedDummyEthernet {
             _ = await managedDummyEthernet
                 .stopForApplicationTerminationIfNeeded()
         }
         usbCoordinator.prepareForIntentionalVMStop()
         vmCoordinator.invalidate()
-        await withCheckedContinuation { continuation in
-            usbCoordinator.stopMonitoring(reason: "Application terminating.") {
-                continuation.resume()
-            }
-        }
+        usbCoordinator.stopMonitoring(reason: "Application terminating.")
     }
 
     func refreshWireGuardTunnelStatus() {

--- a/ThruRNDIS/Stores/WireGuardSessionStore.swift
+++ b/ThruRNDIS/Stores/WireGuardSessionStore.swift
@@ -391,16 +391,14 @@ final class WireGuardSessionStore: ObservableObject {
         )
     }
 
-    func prepareForApplicationTermination(disconnectTunnel: Bool) async {
+    func prepareForApplicationTermination() async {
         isPreparingForApplicationTermination = true
         wireGuardConnectionPrompt = nil
         cancelPendingConnectTask()
         systemExtensionActivationTask?.cancel()
         systemExtensionActivationTask = nil
         tunnelController.invalidateSystemExtensionOperations()
-        if disconnectTunnel {
-            _ = await tunnelController.disconnect(waitUntilStopped: true)
-        }
+        _ = await tunnelController.disconnect(waitUntilStopped: true)
     }
 
     func cancelTunnel(reason: String) {


### PR DESCRIPTION
## Summary

- simplify AppKit termination coordination to one asynchronous cleanup path
- bound privileged-helper XPC requests and fail immediately on interrupted or invalidated connections
- wait for VM asset cancellation, WireGuard shutdown, and configured Dummy Ethernet cleanup before allowing termination
- stop waiting on the AccessoryAccess monitoring callback, which is not required for process exit

## Root cause

Application termination could wait indefinitely when the privileged helper failed to reply. The previous lifecycle implementation also split termination across several pending-application and task states, making completion dependent on multiple callbacks.

## Impact

Quit and reset/relaunch now use the same minimal cleanup path. Helper status and stop calls time out after 10 seconds, while start allows 20 seconds for its normal bounded setup work and issues a compensating stop if it times out.

## Validation

- `git diff --check`
- `xcodebuild -project ThruRNDIS.xcodeproj -scheme ThruRNDIS -configuration Debug -destination platform=macOS -derivedDataPath /tmp/ThruRNDIS-DerivedData-helper-termination-hang CODE_SIGNING_ALLOWED=NO build`
- Xcode build succeeded
- no automated test target is configured