### PR TITLE
fix(app): bound application termination cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,11 +110,11 @@ WireGuard-over-VZNAT architecture as the baseline.
   `AppDelegate` gives operational cleanup, including normal event-log
   preparation, nine seconds. If that deadline expires, it logs the timeout and
   gives event-log file persistence one additional second before allowing the
-  process to exit. The WireGuard tunnel stop wait uses a five-second internal
-  limit. Dummy Ethernet termination uses one five-second deadline shared by
-  waiting for its current operation and sending its stop request, so failures
-  can be logged before the outer deadline. Explicit Stop and Restart actions
-  continue to report failure normally.
+  process to exit. The complete WireGuard termination stop attempt uses one
+  five-second internal limit. Dummy Ethernet termination uses one five-second
+  deadline shared by waiting for its current operation and sending its stop
+  request, so failures can be logged before the outer deadline. Explicit Stop
+  and Restart actions continue to report failure normally.
   The menu bar keeps a
   leading configuration section that lists Settings guidance for each unavailable
   VM Assets, Network Extension, and privileged-helper prerequisite. In normal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,10 +107,14 @@ WireGuard-over-VZNAT architecture as the baseline.
   helper. `AppDelegate` clears the remaining selection only after the reset
   succeeds. A failed stop must leave the helper registered. All
   application-termination cleanup is best-effort and bounded to ten seconds.
-  Network-service termination waits use a five-second internal limit so their
-  failures can be logged before the outer deadline; reserve the final second
-  for bounded event-log persistence, then allow the process to exit. Explicit
-  Stop and Restart actions continue to report failure normally.
+  `AppDelegate` gives operational cleanup, including normal event-log
+  preparation, nine seconds. If that deadline expires, it logs the timeout and
+  gives event-log file persistence one additional second before allowing the
+  process to exit. The WireGuard tunnel stop wait uses a five-second internal
+  limit. Dummy Ethernet termination uses one five-second deadline shared by
+  waiting for its current operation and sending its stop request, so failures
+  can be logged before the outer deadline. Explicit Stop and Restart actions
+  continue to report failure normally.
   The menu bar keeps a
   leading configuration section that lists Settings guidance for each unavailable
   VM Assets, Network Extension, and privileged-helper prerequisite. In normal
@@ -320,12 +324,15 @@ Ethernet.
   Dummy Ethernet remains independent of the tethering data path, does not
   provide connectivity, forwarding, DNS, or NAT, and retains its manual
   Start/Stop/Restart controls in addition to the automatic WireGuard prerequisite.
-  Normal application termination in app-managed mode attempts to stop any
-  configured Dummy Ethernet within the shared ten-second termination-cleanup
-  limit, then exits after logging any failure. The explicit Reset All Settings
+  Normal application termination in app-managed mode gives configured Dummy
+  Ethernet one five-second deadline covering both its current-operation wait
+  and stop request. This runs inside the shared nine-second operational-cleanup
+  deadline. If that outer deadline expires, event-log file persistence gets one
+  additional second before the app exits. The explicit Reset All Settings
   action additionally attempts to unregister the helper and restore the
-  persisted Dummy Ethernet inputs to defaults before quitting; a failure is
-  logged and does not prevent application termination.
+  persisted Dummy Ethernet inputs to defaults before quitting; its Dummy
+  Ethernet stop request has a five-second limit, and a failure is logged without
+  preventing application termination.
   WireGuard Manual Configuration Mode hides Dummy Ethernet settings and menu presentation,
   excludes helper readiness from USB-listener prerequisites, and never starts
   Dummy Ethernet. It does not run app-managed WireGuard or Dummy Ethernet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,11 +104,13 @@ WireGuard-over-VZNAT architecture as the baseline.
   Settings workflow is owned by `TetheringStore`; after its VM, USB, and
   WireGuard cleanup, it asks `DummyEthernetStore` to stop its managed
   configuration and `DummyEthernetHelperStore` to unregister the privileged
-  helper before `AppDelegate` clears the remaining selection and quits.
-  A failed stop must leave the helper registered, and any Dummy Ethernet
-  cleanup failure must prevent quitting. Normal application termination in
-  app-managed mode also waits for any configured Dummy Ethernet operation and
-  its stop request to finish before `AppDelegate` allows the process to exit.
+  helper. `AppDelegate` clears the remaining selection only after the reset
+  succeeds. A failed stop must leave the helper registered. All
+  application-termination cleanup is best-effort and bounded to ten seconds.
+  Network-service termination waits use a five-second internal limit so their
+  failures can be logged before the outer deadline; reserve the final second
+  for bounded event-log persistence, then allow the process to exit. Explicit
+  Stop and Restart actions continue to report failure normally.
   The menu bar keeps a
   leading configuration section that lists Settings guidance for each unavailable
   VM Assets, Network Extension, and privileged-helper prerequisite. In normal
@@ -318,17 +320,19 @@ Ethernet.
   Dummy Ethernet remains independent of the tethering data path, does not
   provide connectivity, forwarding, DNS, or NAT, and retains its manual
   Start/Stop/Restart controls in addition to the automatic WireGuard prerequisite.
-  Normal application termination in app-managed mode waits for any configured
-  Dummy Ethernet to stop before quitting. The explicit Reset All Settings
-  action additionally unregisters the helper and restores the persisted Dummy
-  Ethernet inputs to defaults after stopping the managed configuration.
+  Normal application termination in app-managed mode attempts to stop any
+  configured Dummy Ethernet within the shared ten-second termination-cleanup
+  limit, then exits after logging any failure. The explicit Reset All Settings
+  action additionally attempts to unregister the helper and restore the
+  persisted Dummy Ethernet inputs to defaults before quitting; a failure is
+  logged and does not prevent application termination.
   WireGuard Manual Configuration Mode hides Dummy Ethernet settings and menu presentation,
   excludes helper readiness from USB-listener prerequisites, and never starts
   Dummy Ethernet. It does not run app-managed WireGuard or Dummy Ethernet
   termination cleanup. Changing the mode requires user confirmation and
   application termination. Keep the running process in the mode selected at
-  launch, successfully finish that mode's termination preparation before persisting the
-  target mode, and apply the change the next time the user opens the app. Do
+  launch, persist the target mode after the bounded best-effort termination
+  preparation, and apply the change the next time the user opens the app. Do
   not add live-transition conditions, component-state tracking, or listener
   revalidation for a mode change.
 - `SMAppService` registration is explicit. After a successful register request,
@@ -852,10 +856,11 @@ xcrun notarytool store-credentials "thrurndis-notary"
   be requested while the VM or USB passthrough attachment is active: disconnect
   WireGuard first, stop the VM and wait for its USB attachment lifecycle to end,
   delete the WireGuard directory, stop the managed Dummy Ethernet configuration,
-  unregister its privileged helper, and then clear the Asset selection. It
-  preserves managed Asset releases. If the VM or Dummy Ethernet does not stop,
-  WireGuard deletion fails, or helper removal fails, report the error and do not
-  quit the app. A successful reset creates fresh key files and a generated
+  unregister its privileged helper, and then clear the Asset selection on
+  complete success. It preserves managed Asset releases. If the VM or Dummy
+  Ethernet does not stop, WireGuard deletion fails, or helper removal fails,
+  retain any unfinished state, log the error, and continue application
+  termination. A successful reset creates fresh key files and a generated
   server config on the next launch.
 - Keep WireGuard key material and server configuration read-only. The Connection
   section may edit and persist only the client DNS servers, Endpoint override,

--- a/ThruRNDIS/App/App.swift
+++ b/ThruRNDIS/App/App.swift
@@ -63,6 +63,10 @@ enum App {
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    // Reserve the final second of the ten-second termination budget for logs.
+    private static let terminationCleanupTimeout = Duration.seconds(9)
+    private static let terminationLogFlushTimeout = Duration.seconds(1)
+
     lazy var assetWorkflowCoordinator = VMAssetWorkflowCoordinator()
     lazy var eventLog = EventLogStore(
         filePersistence: EventLogFileStore()
@@ -249,12 +253,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         isTerminating = true
         Task { @MainActor [weak self] in
             guard let self else { return }
-            guard await self.prepareApplicationServicesForTermination() else {
-                self.isTerminating = false
-                sender.reply(toApplicationShouldTerminate: false)
-                self.presentApplicationTerminationFailure()
-                return
-            }
+            await self.prepareApplicationServicesForTermination()
             sender.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater
@@ -343,25 +342,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         quitApplication(
             reason: "app settings reset",
             prepare: { [weak self] in
-                guard let self else {
-                    return false
-                }
+                guard let self else { return }
                 guard await self.store.resetAppSettings() else {
-                    return false
+                    self.eventLog.append(
+                        "Application termination will continue after the app settings reset failed.",
+                        level: .error,
+                        category: .application
+                    )
+                    return
                 }
                 self.assetWorkflowCoordinator.clearSelection()
-                return true
-            },
-            onPreparationFailure: { [weak self] in
-                self?.presentResetFailure()
             }
         )
     }
 
     private func quitApplication(
         reason: String,
-        prepare: @escaping @MainActor () async -> Bool = { true },
-        onPreparationFailure: @escaping @MainActor () -> Void = {},
+        prepare: @escaping @MainActor () async -> Void = {},
         afterTerminationPreparation: @escaping @MainActor () -> Void = {}
     ) {
         guard !isQuittingAfterSettingsChange,
@@ -374,23 +371,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else {
                 return
             }
-            guard await prepare() else {
-                self.finishFailedSettingsChange()
-                onPreparationFailure()
-                return
-            }
-
             self.eventLog.append(
                 "Application will quit after \(reason).",
                 level: .debug,
                 category: .application
             )
 
-            guard await self.prepareApplicationServicesForTermination() else {
-                self.finishFailedSettingsChange()
-                self.presentApplicationTerminationFailure()
-                return
-            }
+            await self.prepareApplicationServicesForTermination(
+                prepare: prepare
+            )
             afterTerminationPreparation()
             self.isPreparedToQuitAfterSettingsChange = true
             self.isQuittingAfterSettingsChange = false
@@ -437,42 +426,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     )
             }
         )
-    }
-
-    private func finishFailedSettingsChange() {
-        isQuittingAfterSettingsChange = false
-        guard isTerminating else { return }
-        isTerminating = false
-        NSApp.reply(toApplicationShouldTerminate: false)
-    }
-
-    private func presentResetFailure(_ message: String? = nil) {
-        let alert = NSAlert()
-        alert.alertStyle = .critical
-        alert.messageText = String(localized: "ThruRNDIS Could Not Reset Settings")
-        alert.informativeText = message ?? store.resetStatusMessage
-        alert.addButton(withTitle: String(localized: "OK"))
-
-        if let window = settingsWindowController?.window {
-            alert.beginSheetModal(for: window)
-        } else {
-            alert.runModal()
-        }
-    }
-
-    private func presentApplicationTerminationFailure() {
-        let alert = NSAlert()
-        alert.alertStyle = .critical
-        alert.messageText = String(localized: "ThruRNDIS Could Not Quit")
-        alert.addButton(withTitle: String(localized: "OK"))
-
-        if let window = settingsWindowController?.window,
-           window.isVisible {
-            alert.beginSheetModal(for: window)
-        } else {
-            NSApp.activate(ignoringOtherApps: true)
-            alert.runModal()
-        }
     }
 
     private func showOnboardingWindow(restart: Bool = false) {
@@ -528,18 +481,67 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return alert.runModal() == .alertFirstButtonReturn
     }
 
-    private func prepareApplicationServicesForTermination() async -> Bool {
+    private func prepareApplicationServicesForTermination(
+        prepare: @escaping @MainActor () async -> Void = {}
+    ) async {
         eventLog.append(
             "Preparing application services for termination.",
             level: .debug,
             category: .application
         )
-        guard await store.prepareForApplicationTermination() else {
-            await eventLog.flushFilePersistence()
-            return false
+
+        let didFinishCleanup = await performTerminationOperation(
+            timeout: Self.terminationCleanupTimeout
+        ) { [weak self] in
+            guard let self else {
+                return
+            }
+            await prepare()
+            async let assetTermination: Void = assetWorkflowCoordinator
+                .prepareForApplicationTermination()
+            await store.prepareForApplicationTermination()
+            await assetTermination
+            await eventLog.prepareForApplicationTermination()
         }
-        await assetWorkflowCoordinator.prepareForApplicationTermination()
-        await eventLog.prepareForApplicationTermination()
-        return true
+
+        guard !didFinishCleanup else { return }
+
+        eventLog.append(
+            "Application termination cleanup timed out; termination will continue.",
+            level: .error,
+            category: .application
+        )
+        _ = await performTerminationOperation(
+            timeout: Self.terminationLogFlushTimeout
+        ) { [weak self] in
+            await self?.eventLog.flushFilePersistence()
+        }
+    }
+
+    private func performTerminationOperation(
+        timeout: Duration,
+        operation: @escaping @MainActor () async -> Void
+    ) async -> Bool {
+        let (results, resultContinuation) = AsyncStream<Bool>.makeStream()
+        let operationTask = Task { @MainActor in
+            await operation()
+            resultContinuation.yield(true)
+        }
+        let timeoutTask = Task.detached {
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
+            resultContinuation.yield(false)
+        }
+        var iterator = results.makeAsyncIterator()
+        let didFinishOperation = await iterator.next() ?? false
+        resultContinuation.finish()
+        timeoutTask.cancel()
+        if !didFinishOperation {
+            operationTask.cancel()
+        }
+        return didFinishOperation
     }
 }

--- a/ThruRNDIS/App/App.swift
+++ b/ThruRNDIS/App/App.swift
@@ -249,7 +249,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         isTerminating = true
         Task { @MainActor [weak self] in
             guard let self else { return }
-            _ = await self.prepareApplicationServicesForTermination()
+            guard await self.prepareApplicationServicesForTermination() else {
+                self.isTerminating = false
+                sender.reply(toApplicationShouldTerminate: false)
+                self.presentApplicationTerminationFailure()
+                return
+            }
             sender.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater
@@ -381,9 +386,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 category: .application
             )
 
-            if await self.prepareApplicationServicesForTermination() {
-                afterTerminationPreparation()
+            guard await self.prepareApplicationServicesForTermination() else {
+                self.finishFailedSettingsChange()
+                self.presentApplicationTerminationFailure()
+                return
             }
+            afterTerminationPreparation()
             self.isPreparedToQuitAfterSettingsChange = true
             self.isQuittingAfterSettingsChange = false
             if self.isTerminating {
@@ -452,6 +460,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    private func presentApplicationTerminationFailure() {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = String(localized: "ThruRNDIS Could Not Quit")
+        alert.addButton(withTitle: String(localized: "OK"))
+
+        if let window = settingsWindowController?.window,
+           window.isVisible {
+            alert.beginSheetModal(for: window)
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+            alert.runModal()
+        }
+    }
+
     private func showOnboardingWindow(restart: Bool = false) {
         if restart || onboardingWindowController?.window?.isVisible != true {
             let presentationID = UUID()
@@ -511,11 +534,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             level: .debug,
             category: .application
         )
-        async let assetTermination: Void = assetWorkflowCoordinator
-            .prepareForApplicationTermination()
-        let didPrepareStore = await store.prepareForApplicationTermination()
-        await assetTermination
+        guard await store.prepareForApplicationTermination() else {
+            await eventLog.flushFilePersistence()
+            return false
+        }
+        await assetWorkflowCoordinator.prepareForApplicationTermination()
         await eventLog.prepareForApplicationTermination()
-        return didPrepareStore
+        return true
     }
 }

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -2693,26 +2693,6 @@
         }
       }
     },
-    "ThruRNDIS Could Not Quit" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ThruRNDIS를 종료할 수 없음"
-          }
-        }
-      }
-    },
-    "ThruRNDIS Could Not Reset Settings" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ThruRNDIS 설정을 초기화할 수 없음"
-          }
-        }
-      }
-    },
     "ThruRNDIS initramfs" : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -2693,6 +2693,16 @@
         }
       }
     },
+    "ThruRNDIS Could Not Quit" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ThruRNDIS를 종료할 수 없음"
+          }
+        }
+      }
+    },
     "ThruRNDIS Could Not Reset Settings" : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
+++ b/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
@@ -107,10 +107,24 @@ final class DummyEthernetPrivilegedHelperClient {
         try await stop(timeout: Self.terminationStopRequestTimeout)
     }
 
-    private func stop(
-        timeout: DispatchTimeInterval?
+    func stopAndWaitUntilFinished(
+        before deadline: DispatchTime
     ) async throws -> DummyEthernetNetworkSnapshot {
-        try await sendRequest(timeout: timeout) { proxy, reply in
+        guard DispatchTime.now().uptimeNanoseconds
+                < deadline.uptimeNanoseconds else {
+            throw DummyEthernetPrivilegedHelperClientError.requestTimedOut
+        }
+        return try await stop(timeout: nil, deadline: deadline)
+    }
+
+    private func stop(
+        timeout: DispatchTimeInterval?,
+        deadline: DispatchTime? = nil
+    ) async throws -> DummyEthernetNetworkSnapshot {
+        try await sendRequest(
+            timeout: timeout,
+            deadline: deadline
+        ) { proxy, reply in
             proxy.stop(withReply: reply)
         }
     }
@@ -130,6 +144,7 @@ final class DummyEthernetPrivilegedHelperClient {
 
     private func sendRequest(
         timeout requestTimeout: DispatchTimeInterval?,
+        deadline requestDeadline: DispatchTime? = nil,
         _ request: @escaping (
             DummyEthernetPrivilegedHelperProtocol,
             @escaping DummyEthernetPrivilegedHelperReply
@@ -190,9 +205,12 @@ final class DummyEthernetPrivilegedHelperClient {
                     ))
                 }
             }
-            if let requestTimeout {
+            let timeoutDeadline = requestDeadline ?? requestTimeout.map {
+                DispatchTime.now() + $0
+            }
+            if let timeoutDeadline {
                 DispatchQueue.global().asyncAfter(
-                    deadline: .now() + requestTimeout
+                    deadline: timeoutDeadline
                 ) { [weak reply] in
                     reply?.resume(with: .failure(
                         DummyEthernetPrivilegedHelperClientError.requestTimedOut

--- a/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
+++ b/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
@@ -65,6 +65,8 @@ final class DummyEthernetPrivilegedHelperClient {
     // 12 seconds waiting for the wired network path before replying.
     private static let startRequestTimeout: DispatchTimeInterval = .seconds(20)
     private static let stopRequestTimeout: DispatchTimeInterval = .seconds(10)
+    private static let terminationStopRequestTimeout: DispatchTimeInterval =
+        .seconds(5)
 
     func status() async throws -> DummyEthernetNetworkSnapshot {
         try await sendRequest(
@@ -102,7 +104,7 @@ final class DummyEthernetPrivilegedHelperClient {
     }
 
     func stopAndWaitUntilFinished() async throws -> DummyEthernetNetworkSnapshot {
-        try await stop(timeout: nil)
+        try await stop(timeout: Self.terminationStopRequestTimeout)
     }
 
     private func stop(

--- a/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
+++ b/ThruRNDIS/Services/DummyEthernetPrivilegedHelperClient.swift
@@ -37,6 +37,25 @@ enum DummyEthernetPrivilegedHelperClientError: Error, Equatable, LocalizedError 
             return message
         }
     }
+
+    var diagnosticDescription: String {
+        switch self {
+        case .applicationBundleIdentifierUnavailable:
+            "The ThruRNDIS bundle identifier is unavailable."
+        case .remoteObjectUnavailable(let message):
+            if let message, !message.isEmpty {
+                "The Dummy Ethernet helper XPC interface is unavailable. \(message)"
+            } else {
+                "The Dummy Ethernet helper XPC interface is unavailable."
+            }
+        case .malformedResponse:
+            "The Dummy Ethernet helper returned an incomplete response."
+        case .requestTimedOut:
+            "The Dummy Ethernet helper did not respond before the request timed out."
+        case .helperFailure(let message):
+            message
+        }
+    }
 }
 
 @MainActor
@@ -137,10 +156,11 @@ final class DummyEthernetPrivilegedHelperClient {
 
             let remoteObject = connection.remoteObjectProxyWithErrorHandler {
                 error in
+                let nsError = error as NSError
                 reply.resume(with: .failure(
                     DummyEthernetPrivilegedHelperClientError
                         .remoteObjectUnavailable(
-                            message: error.localizedDescription
+                            message: "domain=\(nsError.domain), code=\(nsError.code)"
                         )
                 ))
             }

--- a/ThruRNDIS/Services/WireGuardTunnelController.swift
+++ b/ThruRNDIS/Services/WireGuardTunnelController.swift
@@ -12,6 +12,9 @@ private struct ConnectionObservationContext: Equatable {
 
 @MainActor
 final class WireGuardTunnelController {
+    private static let applicationTerminationStopTimeout =
+        Duration.seconds(5)
+
     var onStatusChange: ((WireGuardTunnelStatus) -> Void)?
     var onFailureChange: ((WireGuardTunnelFailure?) -> Void)?
     var onSystemExtensionStatusChange: ((WireGuardSystemExtensionStatus) -> Void)?
@@ -361,6 +364,43 @@ final class WireGuardTunnelController {
             )
             return false
         }
+    }
+
+    func disconnectForApplicationTermination() async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(
+            by: Self.applicationTerminationStopTimeout
+        )
+        let (results, resultContinuation) =
+            AsyncStream<(didFinish: Bool, didStop: Bool)>.makeStream()
+        let disconnectTask = Task { @MainActor in
+            let didStop = await disconnect(waitUntilStopped: true)
+            resultContinuation.yield((true, didStop))
+        }
+        let timeoutTask = Task.detached {
+            do {
+                try await clock.sleep(until: deadline)
+            } catch {
+                return
+            }
+            resultContinuation.yield((false, false))
+        }
+
+        var iterator = results.makeAsyncIterator()
+        let result = await iterator.next() ?? (false, false)
+        resultContinuation.finish()
+        timeoutTask.cancel()
+
+        guard result.didFinish else {
+            disconnectTask.cancel()
+            _ = beginOperation()
+            reportEventLog(
+                "WireGuard tunnel stop timed out after five seconds during application termination.",
+                level: .error
+            )
+            return false
+        }
+        return result.didStop
     }
 
     @discardableResult

--- a/ThruRNDIS/Services/WireGuardTunnelController.swift
+++ b/ThruRNDIS/Services/WireGuardTunnelController.swift
@@ -157,6 +157,10 @@ final class WireGuardTunnelController {
 
     func invalidateSystemExtensionOperations() {
         areSystemExtensionOperationsInvalidated = true
+        cancelPendingSystemExtensionOperations()
+    }
+
+    func cancelPendingSystemExtensionOperations() {
         _ = beginSystemExtensionOperation()
         systemExtensionActivator.cancelPendingRequests()
     }

--- a/ThruRNDIS/Stores/DummyEthernetStore.swift
+++ b/ThruRNDIS/Stores/DummyEthernetStore.swift
@@ -239,7 +239,7 @@ final class DummyEthernetStore: ObservableObject {
             return !Task.isCancelled && snapshot.state == .active
         } catch {
             reportError(
-                "Dummy Ethernet start failed: \(error.localizedDescription)"
+                "Dummy Ethernet start failed: \(Self.diagnosticDescription(for: error))"
             )
             return false
         }
@@ -314,7 +314,7 @@ final class DummyEthernetStore: ObservableObject {
             return true
         } catch {
             reportError(
-                "Dummy Ethernet stop failed: \(error.localizedDescription)"
+                "Dummy Ethernet stop failed: \(Self.diagnosticDescription(for: error))"
             )
             return false
         }
@@ -462,7 +462,7 @@ final class DummyEthernetStore: ObservableObject {
                 )
             } catch {
                 self.reportError(
-                    "Dummy Ethernet \(nextOperation.rawValue) failed: \(error.localizedDescription)"
+                    "Dummy Ethernet \(nextOperation.rawValue) failed: \(Self.diagnosticDescription(for: error))"
                 )
             }
         }
@@ -543,7 +543,7 @@ final class DummyEthernetStore: ObservableObject {
             return !Task.isCancelled && restartedSnapshot.state == .active
         } catch {
             reportError(
-                "Dummy Ethernet restart failed: \(error.localizedDescription)"
+                "Dummy Ethernet restart failed: \(Self.diagnosticDescription(for: error))"
             )
             return false
         }
@@ -584,6 +584,15 @@ final class DummyEthernetStore: ObservableObject {
 
     private func reportError(_ message: String) {
         appendEventLog(message, level: .error)
+    }
+
+    private static func diagnosticDescription(for error: Error) -> String {
+        if let error = error as? DummyEthernetPrivilegedHelperClientError {
+            return error.diagnosticDescription
+        }
+
+        let nsError = error as NSError
+        return "domain=\(nsError.domain), code=\(nsError.code)"
     }
 
     private static func validationResult(

--- a/ThruRNDIS/Stores/DummyEthernetStore.swift
+++ b/ThruRNDIS/Stores/DummyEthernetStore.swift
@@ -362,18 +362,23 @@ final class DummyEthernetStore: ObservableObject {
 
             let snapshot: DummyEthernetNetworkSnapshot
             do {
-                snapshot = try await networkManager.stop()
+                snapshot = try await networkManager
+                    .stopAndWaitUntilFinished()
             } catch {
                 let resetError = DummyEthernetSettingsResetError
                     .stopFailed(error.localizedDescription)
-                reportError(resetError.localizedDescription)
+                reportError(
+                    "Dummy Ethernet settings reset failed while stopping: \(Self.diagnosticDescription(for: error))"
+                )
                 throw resetError
             }
             applySnapshot(snapshot)
             guard snapshot.state == .inactive else {
                 let resetError = DummyEthernetSettingsResetError
                     .stopIncomplete
-                reportError(resetError.localizedDescription)
+                reportError(
+                    "Dummy Ethernet settings reset failed: the managed configuration remained active or degraded."
+                )
                 throw resetError
             }
             appendCompletionEvent(for: .stopping, snapshot: snapshot)
@@ -381,13 +386,17 @@ final class DummyEthernetStore: ObservableObject {
         case .updateRequired:
             let resetError = DummyEthernetSettingsResetError
                 .helperUpdateRequired
-            reportError(resetError.localizedDescription)
+            reportError(
+                "Dummy Ethernet settings reset failed: the helper requires reinstallation."
+            )
             throw resetError
 
         case .unknown:
             let resetError = DummyEthernetSettingsResetError
                 .helperStatusUnavailable
-            reportError(resetError.localizedDescription)
+            reportError(
+                "Dummy Ethernet settings reset failed: the helper registration status is unavailable."
+            )
             throw resetError
 
         case .notRegistered, .notFound:
@@ -403,13 +412,17 @@ final class DummyEthernetStore: ObservableObject {
         } catch {
             let resetError = DummyEthernetSettingsResetError
                 .helperRemovalFailed(error.localizedDescription)
-            reportError(resetError.localizedDescription)
+            reportError(
+                "Dummy Ethernet settings reset failed while removing the helper: \(Self.diagnosticDescription(for: error))"
+            )
             throw resetError
         }
         guard removalStatus == .notRegistered || removalStatus == .notFound else {
             let resetError = DummyEthernetSettingsResetError
                 .helperRemovalIncomplete
-            reportError(resetError.localizedDescription)
+            reportError(
+                "Dummy Ethernet settings reset failed: the helper remained registered."
+            )
             throw resetError
         }
 

--- a/ThruRNDIS/Stores/DummyEthernetStore.swift
+++ b/ThruRNDIS/Stores/DummyEthernetStore.swift
@@ -27,6 +27,9 @@ enum DummyEthernetOperation: String, Equatable {
 
 @MainActor
 final class DummyEthernetStore: ObservableObject {
+    private static let applicationTerminationCleanupTimeout:
+        DispatchTimeInterval = .seconds(5)
+
     let helper: DummyEthernetHelperStore
 
     @Published private(set) var runtimeState: DummyEthernetNetworkState?
@@ -260,8 +263,19 @@ final class DummyEthernetStore: ObservableObject {
 
     @discardableResult
     func stopForApplicationTerminationIfNeeded() async -> Bool {
-        guard await waitUntilCurrentOperationFinishes(),
-              !Task.isCancelled else {
+        let terminationDeadline = DispatchTime.now()
+            + Self.applicationTerminationCleanupTimeout
+        guard await waitUntilCurrentOperationFinishes(
+            before: terminationDeadline
+        ) else {
+            if !Task.isCancelled {
+                reportError(
+                    "Dummy Ethernet application termination cleanup timed out while waiting for the current operation to finish."
+                )
+            }
+            return false
+        }
+        guard !Task.isCancelled else {
             return false
         }
 
@@ -282,7 +296,11 @@ final class DummyEthernetStore: ObservableObject {
 
         return await stopManagedConfiguration(
             requestMessage: "Dummy Ethernet stop requested for application termination.",
-            stopRequest: networkManager.stopAndWaitUntilFinished
+            stopRequest: {
+                try await networkManager.stopAndWaitUntilFinished(
+                    before: terminationDeadline
+                )
+            }
         )
     }
 
@@ -481,15 +499,31 @@ final class DummyEthernetStore: ObservableObject {
         }
     }
 
-    private func waitUntilCurrentOperationFinishes() async -> Bool {
+    private func waitUntilCurrentOperationFinishes(
+        before deadline: DispatchTime? = nil
+    ) async -> Bool {
         while isAnyOperationInProgress {
+            let sleepDuration: Duration
+            if let deadline {
+                let now = DispatchTime.now().uptimeNanoseconds
+                guard now < deadline.uptimeNanoseconds else {
+                    return false
+                }
+                sleepDuration = .nanoseconds(
+                    Int64(min(deadline.uptimeNanoseconds - now, 50_000_000))
+                )
+            } else {
+                sleepDuration = .milliseconds(50)
+            }
             do {
-                try await Task.sleep(for: .milliseconds(50))
+                try await Task.sleep(for: sleepDuration)
             } catch {
                 return false
             }
         }
-        return true
+        guard let deadline else { return true }
+        return DispatchTime.now().uptimeNanoseconds
+            < deadline.uptimeNanoseconds
     }
 
     private func configuration(

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -799,7 +799,6 @@ final class TetheringStore: ObservableObject {
     func prepareForApplicationTermination() async -> Bool {
         guard applicationState != .terminating else { return false }
         applicationState = .terminating
-        shouldRunAccessoryMonitoring = false
         appendEventLog(
             "Application terminating.",
             level: .debug,
@@ -808,23 +807,32 @@ final class TetheringStore: ObservableObject {
         workflowCoordinator.cancelPendingWireGuardConnection(
             reason: "application termination"
         )
-        var didStopManagedNetworkServices = true
         if !appPreferences.isWireGuardManualConfigurationModeEnabled {
             let didStopWireGuard =
-                await wireGuardSession.prepareForApplicationTermination()
+                await wireGuardSession.stopForApplicationTermination()
             let didStopDummyEthernet = if let managedDummyEthernet {
                 await managedDummyEthernet
                     .stopForApplicationTerminationIfNeeded()
             } else {
                 true
             }
-            didStopManagedNetworkServices =
-                didStopWireGuard && didStopDummyEthernet
+            guard didStopWireGuard && didStopDummyEthernet else {
+                applicationState = .active
+                appendEventLog(
+                    "Application termination cancelled: managed network services could not be stopped.",
+                    level: .error,
+                    category: .application
+                )
+                return false
+            }
+
+            wireGuardSession.finishApplicationTerminationPreparation()
         }
+        shouldRunAccessoryMonitoring = false
         usbCoordinator.prepareForIntentionalVMStop()
         vmCoordinator.invalidate()
         usbCoordinator.stopMonitoring(reason: "Application terminating.")
-        return didStopManagedNetworkServices
+        return true
     }
 
     func refreshWireGuardTunnelStatus() {

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -827,8 +827,6 @@ final class TetheringStore: ObservableObject {
                     category: .application
                 )
             }
-
-            wireGuardSession.finishApplicationTerminationPreparation()
         }
         shouldRunAccessoryMonitoring = false
         usbCoordinator.prepareForIntentionalVMStop()

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -1022,7 +1022,7 @@ final class TetheringStore: ObservableObject {
         workflowCoordinator.cancelManagedWireGuardConnection(
             reason: "app settings reset"
         )
-        guard await wireGuardSession.disconnectAndWait() else {
+        guard await wireGuardSession.stopForApplicationTermination() else {
             resetStatusMessage = String(
                 localized: "Could not stop the WireGuard tunnel before resetting app settings."
             )

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -796,8 +796,8 @@ final class TetheringStore: ObservableObject {
         )
     }
 
-    func prepareForApplicationTermination() async -> Bool {
-        guard applicationState != .terminating else { return false }
+    func prepareForApplicationTermination() async {
+        guard applicationState != .terminating else { return }
         applicationState = .terminating
         appendEventLog(
             "Application terminating.",
@@ -808,22 +808,24 @@ final class TetheringStore: ObservableObject {
             reason: "application termination"
         )
         if !appPreferences.isWireGuardManualConfigurationModeEnabled {
-            let didStopWireGuard =
-                await wireGuardSession.stopForApplicationTermination()
-            let didStopDummyEthernet = if let managedDummyEthernet {
+            async let wireGuardStop =
+                wireGuardSession.stopForApplicationTermination()
+            async let dummyEthernetStop = if let managedDummyEthernet {
                 await managedDummyEthernet
                     .stopForApplicationTerminationIfNeeded()
             } else {
                 true
             }
-            guard didStopWireGuard && didStopDummyEthernet else {
-                applicationState = .active
+            let (didStopWireGuard, didStopDummyEthernet) = await (
+                wireGuardStop,
+                dummyEthernetStop
+            )
+            if !didStopWireGuard || !didStopDummyEthernet {
                 appendEventLog(
-                    "Application termination cancelled: managed network services could not be stopped.",
+                    "Application termination will continue after managed network service cleanup failed: WireGuard=\(didStopWireGuard), DummyEthernet=\(didStopDummyEthernet).",
                     level: .error,
                     category: .application
                 )
-                return false
             }
 
             wireGuardSession.finishApplicationTerminationPreparation()
@@ -832,7 +834,6 @@ final class TetheringStore: ObservableObject {
         usbCoordinator.prepareForIntentionalVMStop()
         vmCoordinator.invalidate()
         usbCoordinator.stopMonitoring(reason: "Application terminating.")
-        return true
     }
 
     func refreshWireGuardTunnelStatus() {

--- a/ThruRNDIS/Stores/WireGuardSessionStore.swift
+++ b/ThruRNDIS/Stores/WireGuardSessionStore.swift
@@ -394,14 +394,18 @@ final class WireGuardSessionStore: ObservableObject {
         )
     }
 
-    func prepareForApplicationTermination() async -> Bool {
-        isPreparingForApplicationTermination = true
+    func stopForApplicationTermination() async -> Bool {
         wireGuardConnectionPrompt = nil
         cancelPendingConnectTask()
         systemExtensionActivationTask?.cancel()
         systemExtensionActivationTask = nil
-        tunnelController.invalidateSystemExtensionOperations()
+        tunnelController.cancelPendingSystemExtensionOperations()
         return await tunnelController.disconnect(waitUntilStopped: true)
+    }
+
+    func finishApplicationTerminationPreparation() {
+        isPreparingForApplicationTermination = true
+        tunnelController.invalidateSystemExtensionOperations()
     }
 
     func cancelTunnel(reason: String) {

--- a/ThruRNDIS/Stores/WireGuardSessionStore.swift
+++ b/ThruRNDIS/Stores/WireGuardSessionStore.swift
@@ -400,7 +400,7 @@ final class WireGuardSessionStore: ObservableObject {
         systemExtensionActivationTask?.cancel()
         systemExtensionActivationTask = nil
         tunnelController.cancelPendingSystemExtensionOperations()
-        return await tunnelController.disconnect(waitUntilStopped: true)
+        return await tunnelController.disconnectForApplicationTermination()
     }
 
     func finishApplicationTerminationPreparation() {

--- a/ThruRNDIS/Stores/WireGuardSessionStore.swift
+++ b/ThruRNDIS/Stores/WireGuardSessionStore.swift
@@ -398,13 +398,16 @@ final class WireGuardSessionStore: ObservableObject {
         guard !isPreparingForApplicationTermination else {
             return true
         }
-        isPreparingForApplicationTermination = true
         wireGuardConnectionPrompt = nil
         cancelPendingConnectTask()
         systemExtensionActivationTask?.cancel()
         systemExtensionActivationTask = nil
+        tunnelController.cancelPendingSystemExtensionOperations()
+        let didStop = await tunnelController
+            .disconnectForApplicationTermination()
+        isPreparingForApplicationTermination = true
         tunnelController.invalidateSystemExtensionOperations()
-        return await tunnelController.disconnectForApplicationTermination()
+        return didStop
     }
 
     func cancelTunnel(reason: String) {

--- a/ThruRNDIS/Stores/WireGuardSessionStore.swift
+++ b/ThruRNDIS/Stores/WireGuardSessionStore.swift
@@ -395,17 +395,16 @@ final class WireGuardSessionStore: ObservableObject {
     }
 
     func stopForApplicationTermination() async -> Bool {
+        guard !isPreparingForApplicationTermination else {
+            return true
+        }
+        isPreparingForApplicationTermination = true
         wireGuardConnectionPrompt = nil
         cancelPendingConnectTask()
         systemExtensionActivationTask?.cancel()
         systemExtensionActivationTask = nil
-        tunnelController.cancelPendingSystemExtensionOperations()
-        return await tunnelController.disconnectForApplicationTermination()
-    }
-
-    func finishApplicationTerminationPreparation() {
-        isPreparingForApplicationTermination = true
         tunnelController.invalidateSystemExtensionOperations()
+        return await tunnelController.disconnectForApplicationTermination()
     }
 
     func cancelTunnel(reason: String) {


### PR DESCRIPTION
## Summary

- make application-termination cleanup best-effort within a 10-second overall budget
- bound WireGuard and Dummy Ethernet shutdown work with internal deadlines while preserving detailed error logs
- persist Manual Configuration Mode changes for the next launch even when termination cleanup fails
- remove detailed termination errors from the popup and document the current timeout behavior

## Root cause

Application termination treated helper and network cleanup failures as hard blockers. Some callback-based helper and Network Extension operations could also wait indefinitely, which could prevent the app from quitting or applying a selected configuration-mode change.

## Impact

The app now quits predictably when helper or WireGuard communication fails. Termination-specific cleanup failures are recorded in the event log, while explicit Stop and Restart actions retain their existing error behavior. Reset and normal termination also share bounded cleanup paths without issuing duplicate WireGuard stop requests.

## Validation

- `xcodebuild -project ThruRNDIS.xcodeproj -scheme ThruRNDIS -configuration Debug -destination platform=macOS -derivedDataPath /tmp/ThruRNDIS-DerivedData CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- No automated test target is configured, per repository policy.
