### PR TITLE
feat(helper): automate build-version updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,11 @@ WireGuard-over-VZNAT architecture as the baseline.
 - `ThruRNDISPrivilegedHelper` is a small command-line privileged helper embedded
   at `Contents/MacOS/ThruRNDISPrivilegedHelper`, with its launchd property list
   at `Contents/Library/LaunchDaemons/ThruRNDISPrivilegedHelper.plist`. The app
-  registers it with `SMAppService.daemon` only after an explicit request in the
-  onboarding permissions page or Dummy Ethernet Settings tab. The app bundle is
-  the helper executable's only source; never copy it to
+  initially registers it with `SMAppService.daemon` only after an explicit
+  request in the onboarding permissions page or Dummy Ethernet Settings tab.
+  A registered helper is automatically replaced when its build version differs
+  from the current app build. The app bundle is the helper executable's only
+  source; never copy it to
   `/Library/PrivilegedHelperTools` or maintain a versioned system-path copy.
   This project does not use DriverKit.
 - Linux assets are not bundled with the app. The shared onboarding and Settings
@@ -342,17 +344,16 @@ Ethernet.
   preparation, and apply the change the next time the user opens the app. Do
   not add live-transition conditions, component-state tracking, or listener
   revalidation for a mode change.
-- `SMAppService` registration is explicit. After a successful register request,
-  record the helper-specific installation identity embedded in the helper file
-  rather than the app build number or file-system metadata. Keep that identity
-  stable when only the app marketing/build version changes, and increment it
-  whenever the installed helper implementation changes. Replacing an app bundle
-  can leave the previous root helper process alive; an identity mismatch must
-  block network operations until the user explicitly reinstalls the helper or
-  removes the old registration and installs it again.
-  Do not add runtime helper metadata handshakes, connection-probe retry state,
-  or automatic registration repair in response to refresh or a normal
-  network-operation failure.
+- Initial `SMAppService` registration is explicit. After a successful register
+  request, record the helper executable's embedded `CFBundleVersion`. The helper
+  shares the app build version, and every app update must increment
+  `CURRENT_PROJECT_VERSION`. At app launch, a registered helper build mismatch
+  must block network operations while the app automatically unregisters the old
+  daemon and registers the helper bundled with the current app. Manual Reinstall
+  remains available for development and recovery. Do not add a separate helper
+  installation identity, runtime helper metadata handshake, connection-probe
+  retry state, or automatic registration repair in response to refresh or a
+  normal network-operation failure.
 - The default host address is `192.168.100.2` with a fixed `/24` mask and the
   subnet `.1` address as its router (`192.168.100.1` by default). Settings may
   persist a different RFC 1918 host IPv4 address and separate Bond-member and
@@ -631,6 +632,12 @@ separate `Afcoo/ThruRNDIS_VM_Assets` repository.
   build
 ```
 
+- `CURRENT_PROJECT_VERSION` is the app, Network System Extension, and privileged
+  helper build version. Increment it for every app update, including an app-only
+  update, because the app uses it to detect and automatically replace an older
+  registered privileged helper. Never publish or install a changed app artifact
+  as the same build number.
+
 - Runtime signing checks are meaningful only after the required entitlements are
   included in the provisioning profiles for both the app and Network System
   Extension. The privileged helper shares their signing team but requires no
@@ -820,12 +827,11 @@ xcrun notarytool store-credentials "thrurndis-notary"
   stop Dummy Ethernet. Onboarding may show and manage only its privileged-helper
   permission;
   showing the current helper registration and network state at launch is allowed.
-  Initial helper registration requires the explicit Install action. Replacing
-  the app bundle requires an explicit Reinstall action, or explicit Remove and
-  Install actions, when the registered helper-specific installation identity
-  changes, but an app marketing/build version change alone must not require an
-  update. Refresh and Start/Stop/Restart must never repair registration
-  automatically.
+  Initial helper registration requires the explicit Install action. When the
+  registered helper's recorded `CFBundleVersion` differs from the current app
+  build, app launch automatically unregisters and registers the current bundled
+  helper without an additional confirmation. Manual Reinstall remains available.
+  Refresh and Start/Stop/Restart must never repair registration automatically.
   Do not remove network objects without a user's Stop/Restart action, except
   that application termination stops the managed configuration before exit and
   a confirmed Reset All Settings action removes it before unregistering the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,8 +349,11 @@ Ethernet.
   shares the app build version, and every app update must increment
   `CURRENT_PROJECT_VERSION`. At app launch, a registered helper build mismatch
   must block network operations while the app automatically unregisters the old
-  daemon and registers the helper bundled with the current app. Manual Reinstall
-  remains available for development and recovery. Do not add a separate helper
+  daemon and registers the helper bundled with the current app. Retain the
+  previously registered build until replacement registration succeeds or an
+  explicit removal occurs. This lets an interrupted update resume without
+  making an ordinary first install automatic. Manual Reinstall remains available
+  for development and recovery. Do not add a separate helper
   installation identity, runtime helper metadata handshake, connection-probe
   retry state, or automatic registration repair in response to refresh or a
   normal network-operation failure.

--- a/Configuration/BuildSettings.xcconfig
+++ b/Configuration/BuildSettings.xcconfig
@@ -8,9 +8,8 @@ DEVELOPMENT_TEAM =
 THRURNDIS_APP_BUNDLE_IDENTIFIER = com.example.thrurndis
 THRURNDIS_WIREGUARD_EXTENSION_BUNDLE_IDENTIFIER = $(THRURNDIS_APP_BUNDLE_IDENTIFIER).network-extension
 THRURNDIS_PRIVILEGED_HELPER_BUNDLE_IDENTIFIER = $(THRURNDIS_APP_BUNDLE_IDENTIFIER).privileged-helper
-// Increment only when the installed privileged-helper implementation changes.
-// App marketing/build version changes must leave this identity unchanged.
-THRURNDIS_PRIVILEGED_HELPER_INSTALLATION_IDENTITY = 1
+// The privileged helper uses the app-shared CFBundleVersion for automatic
+// upgrades. Increment CURRENT_PROJECT_VERSION for every app update.
 THRURNDIS_WIREGUARD_APP_GROUP = $(TeamIdentifierPrefix)group.$(THRURNDIS_APP_BUNDLE_IDENTIFIER)
 THRURNDIS_WIREGUARD_MACH_SERVICE = $(THRURNDIS_WIREGUARD_APP_GROUP).network-extension
 THRURNDIS_APP_DISTRIBUTION_PROVISIONING_PROFILE =

--- a/ThruRNDIS/App/App.swift
+++ b/ThruRNDIS/App/App.swift
@@ -308,7 +308,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         let helper = store.dummyEthernet.helper
         helper.refresh()
-        guard helper.registrationStatus == .updateRequired else {
+        guard helper.needsAutomaticUpdate else {
             return
         }
 

--- a/ThruRNDIS/App/App.swift
+++ b/ThruRNDIS/App/App.swift
@@ -205,13 +205,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
+        updateDummyEthernetHelperIfNeeded()
         store.startAccessoryMonitoringOnLaunch()
         DispatchQueue.main.async { [weak self] in
             guard let self else {
                 return
             }
 
-            self.presentDummyEthernetHelperUpdateIfNeeded()
             if self.store.shouldPresentOnboardingOnLaunch
                 || !self.assetWorkflowCoordinator.hasConfiguredAssets {
                 self.showOnboardingWindow()
@@ -302,7 +302,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         consoleWindowController?.show()
     }
 
-    private func presentDummyEthernetHelperUpdateIfNeeded() {
+    private func updateDummyEthernetHelperIfNeeded() {
         guard !appPreferences.isWireGuardManualConfigurationModeEnabled else {
             return
         }
@@ -312,29 +312,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = String(
-            localized: "Dummy Ethernet Helper Update Required"
+        eventLog.append(
+            "Automatically updating the Dummy Ethernet helper for the current app build.",
+            level: .info,
+            category: .application
         )
-        alert.informativeText = String(
-            localized: "The Dummy Ethernet helper must be updated to use ThruRNDIS.\nYou can update it manually later in Settings."
-        )
-        alert.addButton(withTitle: String(localized: "Update"))
-        alert.addButton(withTitle: String(localized: "Not Now"))
-
-        RunLoop.main.perform(inModes: [.modalPanel]) {
-            NSApp.activate(ignoringOtherApps: true)
-        }
-        guard alert.runModal() == .alertFirstButtonReturn else {
-            eventLog.append(
-                "Dummy Ethernet helper update deferred at app launch.",
-                level: .debug,
-                category: .application
-            )
-            return
-        }
-
         store.dummyEthernet.reinstallHelper()
     }
 

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -3551,16 +3551,6 @@
         }
       }
     },
-    "Dummy Ethernet Helper Update Required" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "더미 이더넷 헬퍼 업데이트 필요"
-          }
-        }
-      }
-    },
     "Dummy Ethernet is unavailable in this unsigned build." : {
       "localizations" : {
         "ko" : {
@@ -3901,16 +3891,6 @@
         }
       }
     },
-    "The Dummy Ethernet helper must be updated to use ThruRNDIS.\nYou can update it manually later in Settings." : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ThruRNDIS를 사용하려면 더미 이더넷 헬퍼를 업데이트해야 합니다.\n나중에 설정에서 수동으로 업데이트할 수 있습니다."
-          }
-        }
-      }
-    },
     "The Dummy Ethernet helper XPC interface is unavailable." : {
       "localizations" : {
         "ko" : {
@@ -3987,16 +3967,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "더미 이더넷 중지"
-          }
-        }
-      }
-    },
-    "Update" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "업데이트"
           }
         }
       }

--- a/ThruRNDIS/Services/DummyEthernetPrivilegedHelperRegistrationService.swift
+++ b/ThruRNDIS/Services/DummyEthernetPrivilegedHelperRegistrationService.swift
@@ -8,19 +8,19 @@ import ServiceManagement
 
 @MainActor
 struct DummyEthernetPrivilegedHelperRegistrationService {
-    private static let registeredIdentityKey =
-        "DummyEthernet.registeredHelperIdentity"
+    private static let registeredBuildVersionKey =
+        "DummyEthernet.registeredHelperBuildVersion"
 
     private let service: SMAppService
     private let defaults: UserDefaults
-    private let currentHelperIdentity: String?
+    private let currentHelperBuildVersion: String?
 
     init() {
         service = SMAppService.daemon(
             plistName: ThruRNDISDummyEthernet.helperLaunchDaemonPlistName
         )
         defaults = .standard
-        currentHelperIdentity = Self.helperInstallationIdentity()
+        currentHelperBuildVersion = Self.helperBuildVersion()
     }
 
     func status() -> DummyEthernetHelperRegistrationStatus {
@@ -28,9 +28,9 @@ struct DummyEthernetPrivilegedHelperRegistrationService {
         guard registrationStatus == .enabled else {
             return registrationStatus
         }
-        guard let currentHelperIdentity,
-              defaults.string(forKey: Self.registeredIdentityKey)
-                == currentHelperIdentity else {
+        guard let currentHelperBuildVersion,
+              defaults.string(forKey: Self.registeredBuildVersionKey)
+                == currentHelperBuildVersion else {
             return .updateRequired
         }
         return .enabled
@@ -46,10 +46,10 @@ struct DummyEthernetPrivilegedHelperRegistrationService {
         }
 
         try service.register()
-        if let currentHelperIdentity {
+        if let currentHelperBuildVersion {
             defaults.set(
-                currentHelperIdentity,
-                forKey: Self.registeredIdentityKey
+                currentHelperBuildVersion,
+                forKey: Self.registeredBuildVersionKey
             )
         }
         return status()
@@ -60,14 +60,14 @@ struct DummyEthernetPrivilegedHelperRegistrationService {
         let currentStatus = status()
         switch currentStatus {
         case .notRegistered, .notFound:
-            clearRegisteredIdentity()
+            clearRegisteredBuildVersion()
             return currentStatus
         case .unknown, .enabled, .updateRequired, .requiresApproval:
             break
         }
 
         try await service.unregister()
-        clearRegisteredIdentity()
+        clearRegisteredBuildVersion()
         return status()
     }
 
@@ -75,11 +75,11 @@ struct DummyEthernetPrivilegedHelperRegistrationService {
         SMAppService.openSystemSettingsLoginItems()
     }
 
-    private func clearRegisteredIdentity() {
-        defaults.removeObject(forKey: Self.registeredIdentityKey)
+    private func clearRegisteredBuildVersion() {
+        defaults.removeObject(forKey: Self.registeredBuildVersionKey)
     }
 
-    private static func helperInstallationIdentity() -> String? {
+    private static func helperBuildVersion() -> String? {
         let helperURL = Bundle.main.bundleURL
             .appendingPathComponent("Contents/MacOS", isDirectory: true)
             .appendingPathComponent(
@@ -88,14 +88,12 @@ struct DummyEthernetPrivilegedHelperRegistrationService {
         guard let infoDictionary = CFBundleCopyInfoDictionaryForURL(
             helperURL as CFURL
         ) as? [String: Any],
-            let identity = infoDictionary[
-                ThruRNDISDummyEthernet
-                    .helperInstallationIdentityInfoDictionaryKey
-            ] as? String,
-            !identity.isEmpty else {
+            let buildVersion = infoDictionary[kCFBundleVersionKey as String]
+                as? String,
+            !buildVersion.isEmpty else {
             return nil
         }
-        return identity
+        return buildVersion
     }
 
     private static func registrationStatus(

--- a/ThruRNDIS/Services/DummyEthernetPrivilegedHelperRegistrationService.swift
+++ b/ThruRNDIS/Services/DummyEthernetPrivilegedHelperRegistrationService.swift
@@ -36,6 +36,23 @@ struct DummyEthernetPrivilegedHelperRegistrationService {
         return .enabled
     }
 
+    var needsAutomaticUpdate: Bool {
+        switch status() {
+        case .updateRequired:
+            return true
+        case .notRegistered, .notFound:
+            guard let currentHelperBuildVersion,
+                  let registeredBuildVersion = defaults.string(
+                    forKey: Self.registeredBuildVersionKey
+                  ) else {
+                return false
+            }
+            return registeredBuildVersion != currentHelperBuildVersion
+        case .unknown, .enabled, .requiresApproval:
+            return false
+        }
+    }
+
     func enable() throws -> DummyEthernetHelperRegistrationStatus {
         let currentStatus = status()
         switch currentStatus {
@@ -55,19 +72,23 @@ struct DummyEthernetPrivilegedHelperRegistrationService {
         return status()
     }
 
-    func disable() async throws
+    func disable(preservingRegisteredBuildVersion: Bool = false) async throws
         -> DummyEthernetHelperRegistrationStatus {
         let currentStatus = status()
         switch currentStatus {
         case .notRegistered, .notFound:
-            clearRegisteredBuildVersion()
+            if !preservingRegisteredBuildVersion {
+                clearRegisteredBuildVersion()
+            }
             return currentStatus
         case .unknown, .enabled, .updateRequired, .requiresApproval:
             break
         }
 
         try await service.unregister()
-        clearRegisteredBuildVersion()
+        if !preservingRegisteredBuildVersion {
+            clearRegisteredBuildVersion()
+        }
         return status()
     }
 

--- a/ThruRNDIS/Stores/DummyEthernetHelperStore.swift
+++ b/ThruRNDIS/Stores/DummyEthernetHelperStore.swift
@@ -65,12 +65,19 @@ final class DummyEthernetHelperStore: ObservableObject {
 
     var canReinstall: Bool {
         guard !isOperationInProgress else { return false }
+        if needsAutomaticUpdate {
+            return true
+        }
         switch registrationStatus {
         case .enabled, .updateRequired:
             return true
         case .unknown, .notRegistered, .requiresApproval, .notFound:
             return false
         }
+    }
+
+    var needsAutomaticUpdate: Bool {
+        registrationService.needsAutomaticUpdate
     }
 
     var isReinstallActionPresented: Bool {
@@ -183,7 +190,9 @@ final class DummyEthernetHelperStore: ObservableObject {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let removalStatus = try await self.registrationService.disable()
+                let removalStatus = try await self.registrationService.disable(
+                    preservingRegisteredBuildVersion: true
+                )
                 guard removalStatus == .notRegistered
                         || removalStatus == .notFound else {
                     self.operation = nil

--- a/ThruRNDIS/Stores/DummyEthernetHelperStore.swift
+++ b/ThruRNDIS/Stores/DummyEthernetHelperStore.swift
@@ -176,7 +176,7 @@ final class DummyEthernetHelperStore: ObservableObject {
         guard canReinstall else { return }
         operation = .reinstalling
         appendEventLog(
-            "Dummy Ethernet helper reinstall requested.",
+            "Dummy Ethernet helper reinstall started.",
             level: .debug
         )
 

--- a/ThruRNDIS/Support/ThruRNDISDummyEthernet.swift
+++ b/ThruRNDIS/Support/ThruRNDISDummyEthernet.swift
@@ -16,8 +16,6 @@ enum ThruRNDISDummyEthernet {
         "ThruRNDIS.DummyEthernet.Configuration"
     static let helperExecutableName = "ThruRNDISPrivilegedHelper"
     static let helperLaunchDaemonPlistName = "ThruRNDISPrivilegedHelper.plist"
-    static let helperInstallationIdentityInfoDictionaryKey =
-        "ThruRNDISHelperInstallationIdentity"
 
     private static let helperBundleIdentifierSuffix = ".privileged-helper"
 

--- a/ThruRNDISPrivilegedHelper/Info.plist
+++ b/ThruRNDISPrivilegedHelper/Info.plist
@@ -20,7 +20,5 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>ThruRNDISHelperInstallationIdentity</key>
-	<string>$(THRURNDIS_PRIVILEGED_HELPER_INSTALLATION_IDENTITY)</string>
 </dict>
 </plist>

--- a/script/support/distribution_common.sh
+++ b/script/support/distribution_common.sh
@@ -224,7 +224,6 @@ distribution_validate_privileged_helper() {
   local helper_bundle_identifier
   local helper_bundle_version
   local helper_identifier
-  local helper_installation_identity
   local helper_package_type
   local helper_short_version
   local helper_signing_details
@@ -278,8 +277,6 @@ distribution_validate_privileged_helper() {
     "$helper_path" CFBundleShortVersionString)"
   helper_bundle_version="$(distribution_embedded_info_value \
     "$helper_path" CFBundleVersion)"
-  helper_installation_identity="$(distribution_embedded_info_value \
-    "$helper_path" ThruRNDISHelperInstallationIdentity)"
   helper_package_type="$(distribution_embedded_info_value \
     "$helper_path" CFBundlePackageType)"
   app_short_version="$(/usr/libexec/PlistBuddy \
@@ -290,8 +287,6 @@ distribution_validate_privileged_helper() {
     "privileged-helper embedded bundle ID is $helper_bundle_identifier instead of $expected_helper_identifier"
   [[ -n "$helper_short_version" && -n "$helper_bundle_version" ]] || distribution_fail \
     "privileged-helper embedded version metadata is missing"
-  [[ -n "$helper_installation_identity" ]] || distribution_fail \
-    "privileged-helper embedded installation identity is missing"
   [[ "$helper_short_version" == "$app_short_version" && \
       "$helper_bundle_version" == "$app_bundle_version" ]] || distribution_fail \
     "the app and privileged helper have different version/build values"


### PR DESCRIPTION
## Summary

- Tie the privileged helper's `CFBundleVersion` to the app's `CURRENT_PROJECT_VERSION` and remove the separate installation identity.
- Automatically reinstall an outdated helper at app launch without prompting, while keeping first-time installation explicit.
- Preserve the previously registered build number during reinstall so an interrupted build update resumes on the next launch; explicit removal still clears it.
- Keep automatic update events in the application log and remove obsolete confirmation UI, localization, metadata, and distribution validation.

## Why

Replacing the app bundle can leave the previously registered privileged helper active. When its version is not detected as stale, Dummy Ethernet setup can degrade and block the managed WireGuard connection flow. Using the shared build number makes every app update refresh the bundled helper consistently.

## Developer impact

Every app update must increment `CURRENT_PROJECT_VERSION`. This change intentionally keeps the current build number at `12`.

## Validation

- `xcodebuild -project ThruRNDIS.xcodeproj -scheme ThruRNDIS -configuration Debug -derivedDataPath /tmp/ThruRNDIS-Review-DerivedData CODE_SIGNING_ALLOWED=NO build`
- `git diff --check 4de6c6fb275f79d2c35a61da826b7e1af02ea11b`
- Validated the string catalog JSON and distribution shell script syntax.
- Confirmed both the built app and privileged helper use `CFBundleVersion = 12`.

No automated test suite is configured for this repository.