### PR TITLE
fix(onboarding): quit app when window closes

### DIFF
--- a/ThruRNDIS/App/App.swift
+++ b/ThruRNDIS/App/App.swift
@@ -421,6 +421,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 onFinish: { [weak self] in
                     self?.closeOnboardingWindow(presentationID: presentationID)
                 },
+                onUserCloseRequest: {
+                    NSApp.terminate(nil)
+                },
                 onClose: { [weak self] in
                     self?.onboardingWindowDidClose(presentationID: presentationID)
                 }

--- a/ThruRNDIS/Presentation/OnboardingWindowController.swift
+++ b/ThruRNDIS/Presentation/OnboardingWindowController.swift
@@ -121,6 +121,7 @@ private final class OnboardingWindowResizeBridge {
 
 @MainActor
 final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
+    private let onUserCloseRequest: () -> Void
     private let onClose: () -> Void
     private let resizeBridge: OnboardingWindowResizeBridge
 
@@ -128,8 +129,10 @@ final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
         store: TetheringStore,
         assetWorkflowCoordinator: VMAssetWorkflowCoordinator,
         onFinish: @escaping () -> Void,
+        onUserCloseRequest: @escaping () -> Void,
         onClose: @escaping () -> Void
     ) {
+        self.onUserCloseRequest = onUserCloseRequest
         self.onClose = onClose
         let resizeBridge = OnboardingWindowResizeBridge()
         self.resizeBridge = resizeBridge
@@ -191,6 +194,11 @@ final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
         showWindow(nil)
         window?.makeKeyAndOrderFront(nil)
         resizeBridge.scheduleInitialUpdate()
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        onUserCloseRequest()
+        return false
     }
 
     func windowWillClose(_ notification: Notification) {


### PR DESCRIPTION
## Summary

- request application termination when the onboarding window is closed with the close button or Command-W
- keep the onboarding window visible while termination cleanup or confirmation is pending
- preserve the existing Finish flow so completing onboarding closes only the window

## Verification

- ./script/build_and_run.sh --verify
- No automated test target is configured in this repository.