### PR TITLE
docs(contributing): align guidance with managed VZNAT routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,13 +10,13 @@ body:
       value: |
         Thank you for helping improve ThruRNDIS.
 
-        Do not include WireGuard private keys, complete client configurations,
-        provisioning profiles, signing credentials, or other secrets. Report
+        Do not include provisioning profiles, signing credentials, or other
+        secrets. Report
         vulnerabilities through [GitHub's private security advisory form](https://github.com/Afcoo/ThruRNDIS/security/advisories/new),
         not through a public issue.
 
-        ThruRNDIS 개선에 도움을 주셔서 감사합니다. WireGuard 개인 키, 전체
-        클라이언트 설정, 프로비저닝 프로파일, 서명 자격 증명 등 비밀 정보는
+        ThruRNDIS 개선에 도움을 주셔서 감사합니다. 프로비저닝 프로파일,
+        서명 자격 증명 등 비밀 정보는
         첨부하지 마세요. 보안 취약점은 공개 Issue가 아닌 [GitHub 비공개 보안
         신고 양식](https://github.com/Afcoo/ThruRNDIS/security/advisories/new)을
         이용해 주세요.
@@ -29,8 +29,7 @@ body:
         - VM Asset installation or selection
         - USB approval, detection, or passthrough
         - VM boot or lifecycle
-        - WireGuard configuration or connection
-        - Network System Extension
+        - Privileged helper registration or IPv4 routing
         - Onboarding, Settings, or menu bar
         - Installation, signing, or distribution
         - Other
@@ -120,8 +119,7 @@ body:
       description: |
         Attach exported app event logs or paste relevant serial-console excerpts.
         Wrap pasted text in fenced code blocks when practical.
-        Redact private keys, complete WireGuard client configurations, signing
-        credentials, personal paths, and device identifiers.
+        Redact signing credentials, personal paths, and device identifiers.
 
   - type: textarea
     id: additional-context

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,12 +9,12 @@ body:
     attributes:
       value: |
         Please describe the user problem before proposing an implementation.
-        Changes to the WireGuard-over-VZNAT data path, USB passthrough lifecycle,
-        key handling, signing model, or VM Asset boundary need explicit
+        Changes to the VZNAT host-route data path, USB passthrough lifecycle,
+        privileged-helper boundary, signing model, or VM Asset boundary need explicit
         architecture discussion.
 
-        구현 방법보다 사용자 문제를 먼저 설명해 주세요. WireGuard-over-VZNAT
-        데이터 경로, USB 패스스루 수명 주기, 키 처리, 서명 모델 또는 VM Asset
+        구현 방법보다 사용자 문제를 먼저 설명해 주세요. VZNAT 호스트 라우트
+        데이터 경로, USB 패스스루 수명 주기, privileged helper, 서명 모델 또는 VM Asset
         경계를 바꾸는 제안은 별도의 아키텍처 논의가 필요합니다.
 
   - type: dropdown
@@ -25,8 +25,7 @@ body:
         - VM Asset installation or selection
         - USB approval, detection, or passthrough
         - VM boot or lifecycle
-        - WireGuard configuration or connection
-        - Network System Extension
+        - Privileged helper or IPv4 routing
         - Onboarding, Settings, or menu bar
         - Logging or diagnostics
         - Installation, signing, or distribution
@@ -62,8 +61,8 @@ body:
     attributes:
       label: Architecture impact / 아키텍처 영향
       description: |
-        Note any expected impact on USB passthrough, VM lifecycle, WireGuard,
-        Network System Extension, VM Assets, signing, security, or privacy.
+        Note any expected impact on USB passthrough, VM lifecycle, VZNAT host
+        routes, the privileged helper, VM Assets, signing, security, or privacy.
 
   - type: textarea
     id: additional-context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 - [ ] `./script/build_and_run.sh --verify`
 - [ ] Checks run and unverified runtime paths are documented
 - [ ] Signed Runtime validation with `./script/build_and_install.sh`
-- [ ] Real USB/WireGuard validation
+- [ ] Real USB/VZNAT route validation
 - [ ] Not applicable; explanation:
 
 ## User-facing impact
@@ -26,7 +26,7 @@
 
 ## Security and architecture
 
-<!-- Describe changes to USB, VM lifecycle, WireGuard, Network System Extension, VM Assets, signing, privacy, or key handling. Write "None" when there is no impact. -->
+<!-- Describe changes to USB, VM lifecycle, VZNAT host routes, the privileged helper, VM Assets, signing, security, or privacy. Write "None" when there is no impact. -->
 
 ## Checklist
 
@@ -35,5 +35,5 @@
 - [ ] Behavior changes include appropriate build or runtime validation, with unavailable paths explained.
 - [ ] User-facing behavior and operational changes are documented.
 - [ ] New, moved, renamed, or deleted Swift files are reflected in Xcode groups, target membership, and build phases.
-- [ ] No private keys, complete WireGuard client configurations, credentials, provisioning profiles, personal signing values, or local build artifacts are included.
+- [ ] No credentials, provisioning profiles, personal signing values, or local build artifacts are included.
 - [ ] Guest VM scripts and VM Asset build tooling remain in `Afcoo/ThruRNDIS_VM_Assets`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing to ThruRNDIS
 
 Thank you for helping improve ThruRNDIS. The project is a macOS 27+ menu-bar
-app that uses a WireGuard Network System Extension, a Virtualization framework
-Linux VM, and public AccessoryAccess USB passthrough APIs.
+app that uses a Virtualization framework Linux VM, public AccessoryAccess USB
+passthrough APIs, and a narrowly scoped privileged helper for the host-side
+Bond, feth pair, VZNAT bridge membership, and IPv4 routes.
 
 Before making a substantial change, read [AGENTS.md](AGENTS.md). It documents
 the current architecture, ownership boundaries, build paths, signing
@@ -20,34 +21,41 @@ requirements, and verification expectations.
 - Report suspected security vulnerabilities privately according to
   [SECURITY.md](SECURITY.md). Do not open a public issue.
 
-Never attach WireGuard private keys, complete client configurations,
-provisioning profiles, signing credentials, notary credentials, or other
-secrets. Redact personal paths and device identifiers from logs when they are
-not needed to reproduce a problem.
+Never attach provisioning profiles, signing credentials, notary credentials,
+or other secrets. Redact personal paths and device identifiers from logs when
+they are not needed to reproduce a problem.
 
 ## Architecture boundaries
 
-The supported data path is:
+The proof-of-concept IPv4 data path is:
 
 ```text
-ThruRNDIS WireGuardKit Network System Extension
--> VZNAT guest endpoint
--> guest WireGuard interface
--> guest nftables masquerade
--> USB RNDIS upstream
+macOS routes 0.0.0.0/1 and 128.0.0.0/1
+-> Ethernet Bond 192.168.100.2
+-> feth0 <-> feth1
+-> VM-created VZNAT bridge
+-> guest eth0 192.168.100.1
+-> guest eth0 forwarding and nftables masquerade
+-> USB RNDIS upstream on guest usb0
 ```
 
-Changes that replace this path with an app-local packet relay, vmnet, bridged
-networking, or route-command UI are outside the current architecture. Propose
-an architecture change in an issue before implementing it.
+The app obtains the guest address and RNDIS readiness from serial-console
+markers. Only the authenticated privileged helper may create or remove the
+host network configuration, mutate bridge membership, or install routes. The
+unprivileged app must not execute `route`, `ifconfig`, `networksetup`, or
+another administrative networking command itself.
 
 Keep these boundaries intact:
 
 - USB passthrough uses an AccessoryAccess `AAUSBAccessory` with the public
   `VZUSBPassthroughDeviceConfiguration(device:)` API.
-- The app does not inspect or relay packet payloads.
-- Client private keys are not persisted in tunnel-provider configuration or
-  shared with the guest.
+- The VM uses `VZNATNetworkDeviceAttachment`. The POC helper discovers the
+  implementation bridge after VM start and adds only its owned `feth1` peer.
+- The app and helper do not inspect or relay packet payloads.
+- The helper manages only its recorded Bond, feth pair, bridge membership, and
+  global/Bond-scoped entries for the two exact `/1` prefixes. Cleanup withdraws
+  routes before detaching and destroying the owned interfaces.
+- IPv6 routing is out of scope for this proof of concept.
 - Guest VM scripts, dependency locking, and VM Asset release tooling belong in
   `Afcoo/ThruRNDIS_VM_Assets`, not this repository.
 - Personal signing values and `Configuration/LocalSigning.xcconfig` must not be
@@ -69,9 +77,9 @@ The normal minimum verification after a code change is:
 
 The repository currently has no automated test target. Do not add test code or
 test-only production abstractions without a separately defined test plan. Real
-USB passthrough, Virtualization, Network System Extension activation, and
-WireGuard runtime validation require the signed Runtime build, approved
-entitlements, and appropriate hardware:
+USB passthrough, Virtualization, privileged-helper registration, and route
+runtime validation require the signed Runtime build, administrator approval,
+and appropriate hardware:
 
 ```sh
 ./script/build_and_install.sh
@@ -123,7 +131,7 @@ larger designs should link one with `Closes #123` when applicable.
 Pull request titles use Conventional Commits syntax:
 
 ```text
-feat(wireguard): validate endpoint overrides
+feat(network): bridge the feth peer into the VM network
 fix(usb): serialize detach handling
 docs: clarify Runtime signing
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,9 @@ The normal minimum verification after a code change is:
 The repository currently has no automated test target. Do not add test code or
 test-only production abstractions without a separately defined test plan. Real
 USB passthrough, Virtualization, privileged-helper registration, and route
-runtime validation require the signed Runtime build, administrator approval,
-and appropriate hardware:
+runtime validation require the signed Runtime build with approved
+AccessoryAccess and Virtualization entitlements, administrator approval, and
+appropriate hardware:
 
 ```sh
 ./script/build_and_install.sh


### PR DESCRIPTION
## Summary

Update contributor guidance and GitHub community templates for the managed VZNAT host-routing architecture introduced by #16.

## Changes

- Replace WireGuard and Network System Extension references with privileged-helper and IPv4-routing guidance.
- Document the proof-of-concept data path, helper trust boundary, and Runtime entitlement requirements.
- Align issue categories, PR validation prompts, and security checklists with the new architecture.

## Related issue

Depends on #16. Merge after that pull request.

## Validation

- [ ] ./script/build_and_run.sh --verify
- [ ] Checks run and unverified runtime paths are documented
- [ ] Signed Runtime validation with ./script/build_and_install.sh
- [ ] Real USB/VZNAT route validation
- [x] Not applicable; documentation and GitHub-template changes only. The branch diff was reviewed against origin/main.

## User-facing impact

Contributor-facing documentation and repository templates change. There is no app UI or runtime behavior change.

## Security and architecture

Documentation only. The guidance describes the architecture implemented by #16; this pull request does not change runtime security behavior.

## Checklist

- [x] The pull request has one focused purpose.
- [x] The title follows Conventional Commits.
- [x] Behavior changes include appropriate build or runtime validation, with unavailable paths explained.
- [x] User-facing behavior and operational changes are documented.
- [x] New, moved, renamed, or deleted Swift files are reflected in Xcode groups, target membership, and build phases; no Swift files changed.
- [x] No credentials, provisioning profiles, personal signing values, or local build artifacts are included.
- [x] Guest VM scripts and VM Asset build tooling remain in Afcoo/ThruRNDIS_VM_Assets.