### PR TITLE
docs(readme): document managed VZNAT routing

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -28,7 +28,7 @@ ThruRNDIS는 macOS에서 안드로이드의 RNDIS 방식 USB 테더링을 사용
 ## 요구 사항
 
 - macOS 27 이상
-- Network Extension 및 LaunchDaemon 권한
+- AccessoryAccess, Virtualization 및 LaunchDaemon 권한
 
 ## 설치 방법
 
@@ -44,20 +44,20 @@ brew install --cask afcoo/tap/thrurndis
 
 ## 사용 방법
 
-1. **VM Assets 설치:** 온보딩 또는 설정에서 최신 VM Assets를 설치합니다.
+1. **VM Assets 설치:** 온보딩 또는 설정에서 최신 호환 VM Assets를 설치합니다.
 2. **USB 장치 전달:** 메뉴 막대의 **가상 머신 액세서리**에서 USB 장치를 **ThruRNDIS**로 전달합니다.
 
    ![가상 머신 액세서리에서 USB 장치를 ThruRNDIS로 전달하는 과정](./images/accessory-access-onboarding.gif)
 
-3. **USB 기기 연결 확인:** USB 기기 연결 팝업에서 연결을 승인합니다.
-4. **WireGuard 연결 확인:** WireGuard 연결 팝업에서 연결을 승인합니다.
+3. **(선택 사항) 포트 포워딩:** 기기를 연결하기 전에 **설정 → 네트워크 라우팅**에서 RNDIS 장치로 공유할 TCP/UDP 포트를 설정합니다.
+4. **USB 기기 연결 확인:** USB 기기 연결 팝업에서 연결을 승인합니다.
 
 ## 작동 원리
 
 ```text
-ThruRNDIS WireGuard Network System Extension
--> VZNAT guest endpoint UDP/<ListenPort>
--> Linux VM wg0
+macOS
+-> Ethernet Bond 및 feth pair
+-> VZNAT bridge를 통한 Linux VM
 -> nftables masquerade
 -> Linux VM usb0
 -> RNDIS USB tethering device
@@ -67,9 +67,9 @@ ThruRNDIS WireGuard Network System Extension
 
 ThruRNDIS는 경량 Linux VM을 실행하고 macOS에 연결된 RNDIS 장치를 USB passthrough로 VM에 전달합니다.
 
-macOS와 VM은 VZNAT을 통해 WireGuard 터널로 연결되며, VM은 WireGuard를 통해 전달된 macOS의 트래픽을 인식된 RNDIS 장치에 전달합니다.
+macOS는 VM의 VZNAT bridge에 연결된 Ethernet Bond와 feth pair를 통해 VM과 통신합니다. VM은 IPv4 트래픽을 USB RNDIS 인터페이스로 전달합니다.
 
-ThruRNDIS는 VZNAT을 통한 WireGuard 터널 연결을 위해 [`변형된 wireguard-apple 포크`](https://github.com/Afcoo/wireguard-apple/tree/thrurndis-vznat-bind)를 사용합니다.
+TCP/UDP 포트 포워딩은 Linux VM의 nftables DNAT/SNAT 규칙으로 처리하며, 일치하는 RNDIS 트래픽을 목적지 포트 변경 없이 macOS로 전달합니다.
 
 ## 라이선스
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -45,7 +45,7 @@ brew install --cask afcoo/tap/thrurndis
 ## 사용 방법
 
 1. **VM Assets 설치:** 온보딩 또는 설정에서 최신 호환 VM Assets를 설치합니다.
-2. **USB 장치 전달:** 메뉴 막대의 **가상 머신 액세서리**에서 USB 장치를 **ThruRNDIS**로 전달합니다.
+2. **USB 장치 패스스루:** 메뉴 막대의 **가상 머신 액세서리**에서 USB 장치를 **ThruRNDIS**로 전달합니다.
 
    ![가상 머신 액세서리에서 USB 장치를 ThruRNDIS로 전달하는 과정](./images/accessory-access-onboarding.gif)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -28,7 +28,7 @@ ThruRNDIS는 macOS에서 안드로이드의 RNDIS 방식 USB 테더링을 사용
 ## 요구 사항
 
 - macOS 27 이상
-- AccessoryAccess, Virtualization 및 LaunchDaemon 권한
+- Privileged Helper 승인
 
 ## 설치 방법
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -83,6 +83,28 @@ ThruRNDIS의 네트워크 헬퍼는 Ethernet Bond와 feth pair를 구성하고 f
 
 TCP/UDP 포트 포워딩은 Linux VM의 nftables DNAT/SNAT 규칙으로 처리하며, 일치하는 RNDIS 트래픽을 목적지 포트 변경 없이 macOS로 전달합니다.
 
+<details>
+<summary><em>(Legacy) 버전 v0.4.0 이전</em></summary>
+
+```text
+ThruRNDIS WireGuard Network System Extension
+-> VZNAT guest endpoint UDP/<ListenPort>
+-> Linux VM wg0
+-> nftables masquerade
+-> Linux VM usb0
+-> RNDIS USB tethering device
+```
+
+*참조: [`Virtualization Framework: VZUSBPassthroughDevice`](https://developer.apple.com/documentation/virtualization/vzusbpassthroughdevice)*
+
+ThruRNDIS는 경량 Linux VM을 실행하고 macOS에 연결된 RNDIS 장치를 USB passthrough로 VM에 전달합니다.
+
+macOS와 VM은 VZNAT을 통해 WireGuard 터널로 연결되며, VM은 WireGuard를 통해 전달된 macOS의 트래픽을 인식된 RNDIS 장치에 전달합니다.
+
+ThruRNDIS는 VZNAT을 통한 WireGuard 터널 연결을 위해 [`변형된 wireguard-apple 포크`](https://github.com/Afcoo/wireguard-apple/tree/thrurndis-vznat-bind)를 사용합니다.
+
+</details>
+
 ## 라이선스
 
 ThruRNDIS 소스 코드는 [MIT License](./LICENSE.txt)에 따라 배포됩니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -55,19 +55,28 @@ brew install --cask afcoo/tap/thrurndis
 ## 작동 원리
 
 ```text
-macOS
--> Ethernet Bond 및 feth pair
--> VZNAT bridge를 통한 Linux VM
--> nftables masquerade
--> Linux VM usb0
--> RNDIS USB tethering device
+[macOS]
+IPv4 routes
+→ Ethernet Bond
+→ feth0 (Bond member) ↔ feth1 (VZNAT bridge member)
+  ⌃
+  │ VZNAT bridge
+  ⌄
+[Linux VM]
+eth0
+→ IPv4 forwarding + nftables masquerade
+→ usb0
+  ⌃
+  │ USB passthrough
+  ⌄
+[RNDIS Device]
 ```
 
 *참조: [`Virtualization Framework: VZUSBPassthroughDevice`](https://developer.apple.com/documentation/virtualization/vzusbpassthroughdevice)*
 
 ThruRNDIS는 경량 Linux VM을 실행하고 macOS에 연결된 RNDIS 장치를 USB passthrough로 VM에 전달합니다.
 
-macOS는 VM의 VZNAT bridge에 연결된 Ethernet Bond와 feth pair를 통해 VM과 통신합니다. VM은 IPv4 트래픽을 USB RNDIS 인터페이스로 전달합니다.
+ThruRNDIS의 네트워크 헬퍼는 Ethernet Bond와 feth pair를 구성하고 feth peer를 VM의 VZNAT bridge에 연결하여 macOS의 IPv4 트래픽이 VM으로 라우팅되도록 합니다. VM은 이 트래픽을 전달하고 NAT masquerade를 적용해 USB RNDIS 인터페이스로 내보냅니다.
 
 TCP/UDP 포트 포워딩은 Linux VM의 nftables DNAT/SNAT 규칙으로 처리하며, 일치하는 RNDIS 트래픽을 목적지 포트 변경 없이 macOS로 전달합니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -54,6 +54,9 @@ brew install --cask afcoo/tap/thrurndis
 
 ## 작동 원리
 
+> [!WARNING]
+> 0.4.0 버전 이상부터는 WireGuard 연결을 사용하지 않습니다.
+
 ```text
 [macOS]
 IPv4 routes

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ThruRNDIS is a Swift app based on the Virtualization framework that enables Andr
 ## Requirements
 
 - macOS 27 or later
-- Network Extension and LaunchDaemon permissions
+- AccessoryAccess, Virtualization, and LaunchDaemon permissions
 
 ## Installation
 
@@ -44,20 +44,20 @@ brew install --cask afcoo/tap/thrurndis
 
 ## How to Use
 
-1. **Install VM Assets:** Install the latest VM Assets during onboarding or in Settings.
+1. **Install VM Assets:** Install the latest compatible VM Assets during onboarding or in Settings.
 2. **Pass through the USB device:** In **Virtual Machine Accessories** in the menu bar, connect the USB device to **ThruRNDIS**.
 
    ![Passing a USB device to ThruRNDIS from Virtual Machine Accessories](./images/accessory-access-onboarding.gif)
 
-3. **Confirm the USB device connection:** Approve the connection in the USB device connection pop-up.
-4. **Confirm the WireGuard connection:** Approve the connection in the WireGuard connection pop-up.
+3. **(Optional) Port forwarding:** Before connecting the device, configure the TCP/UDP ports to expose through the RNDIS device in **Settings → Network Routing**.
+4. **Confirm the USB device connection:** Approve the connection in the USB device connection pop-up.
 
 ## How It Works
 
 ```text
-ThruRNDIS WireGuard Network System Extension
--> VZNAT guest endpoint UDP/<ListenPort>
--> Linux VM wg0
+macOS
+-> Ethernet Bond and feth pair
+-> Linux VM through the VZNAT bridge
 -> nftables masquerade
 -> Linux VM usb0
 -> RNDIS USB tethering device
@@ -67,9 +67,9 @@ ThruRNDIS WireGuard Network System Extension
 
 ThruRNDIS runs a lightweight Linux VM and passes the RNDIS device connected to macOS through to the VM using USB passthrough.
 
-macOS and the VM are connected by a WireGuard tunnel over VZNAT, and the VM forwards macOS traffic received through WireGuard to the recognized RNDIS device.
+macOS connects to the VM through an Ethernet Bond and feth pair attached to the VM's VZNAT bridge. The VM forwards IPv4 traffic through the USB RNDIS interface.
 
-ThruRNDIS uses a [modified `wireguard-apple` fork](https://github.com/Afcoo/wireguard-apple/tree/thrurndis-vznat-bind) to establish the WireGuard tunnel over VZNAT.
+TCP/UDP port forwarding is handled by nftables DNAT/SNAT rules in the Linux VM, which forward matching RNDIS traffic to macOS without changing the destination port.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ ThruRNDIS's Network Helper configures an Ethernet Bond and feth pair and attache
 
 TCP/UDP port forwarding is handled by nftables DNAT/SNAT rules in the Linux VM, which forward matching RNDIS traffic to macOS without changing the destination port.
 
+<details>
+<summary><em>(Legacy) Before v0.4.0</em></summary>
+
+```text
+ThruRNDIS WireGuard Network System Extension
+-> VZNAT guest endpoint UDP/<ListenPort>
+-> Linux VM wg0
+-> nftables masquerade
+-> Linux VM usb0
+-> RNDIS USB tethering device
+```
+
+*Reference: [`Virtualization Framework: VZUSBPassthroughDevice`](https://developer.apple.com/documentation/virtualization/vzusbpassthroughdevice)*
+
+ThruRNDIS runs a lightweight Linux VM and passes the RNDIS device connected to macOS through to the VM using USB passthrough.
+
+macOS and the VM are connected by a WireGuard tunnel over VZNAT, and the VM forwards macOS traffic received through WireGuard to the recognized RNDIS device.
+
+ThruRNDIS uses a [modified `wireguard-apple` fork](https://github.com/Afcoo/wireguard-apple/tree/thrurndis-vznat-bind) to establish the WireGuard tunnel over VZNAT.
+
+</details>
+
 ## License
 
 ThruRNDIS source code is distributed under the [MIT License](./LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -55,19 +55,28 @@ brew install --cask afcoo/tap/thrurndis
 ## How It Works
 
 ```text
-macOS
--> Ethernet Bond and feth pair
--> Linux VM through the VZNAT bridge
--> nftables masquerade
--> Linux VM usb0
--> RNDIS USB tethering device
+[macOS]
+IPv4 routes
+→ Ethernet Bond
+→ feth0 (Bond member) ↔ feth1 (VZNAT bridge member)
+  ⌃
+  │ VZNAT bridge
+  ⌄
+[Linux VM]
+eth0
+→ IPv4 forwarding + nftables masquerade
+→ usb0
+  ⌃
+  │ USB passthrough
+  ⌄
+[RNDIS Device]
 ```
 
 *Reference: [`Virtualization Framework: VZUSBPassthroughDevice`](https://developer.apple.com/documentation/virtualization/vzusbpassthroughdevice)*
 
 ThruRNDIS runs a lightweight Linux VM and passes the RNDIS device connected to macOS through to the VM using USB passthrough.
 
-macOS connects to the VM through an Ethernet Bond and feth pair attached to the VM's VZNAT bridge. The VM forwards IPv4 traffic through the USB RNDIS interface.
+ThruRNDIS's Network Helper configures an Ethernet Bond and feth pair and attaches the feth peer to the VM's VZNAT bridge so that macOS IPv4 traffic is routed through the VM. The VM forwards this traffic and applies NAT masquerade before sending it through the USB RNDIS interface.
 
 TCP/UDP port forwarding is handled by nftables DNAT/SNAT rules in the Linux VM, which forward matching RNDIS traffic to macOS without changing the destination port.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ brew install --cask afcoo/tap/thrurndis
 
 ## How It Works
 
+> [!WARNING]
+> ThruRNDIS 0.4.0+ does not use WireGuard.
+
 ```text
 [macOS]
 IPv4 routes

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ThruRNDIS is a Swift app based on the Virtualization framework that enables Andr
 ## Requirements
 
 - macOS 27 or later
-- AccessoryAccess, Virtualization, and LaunchDaemon permissions
+- Privileged Helper approval
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ brew install --cask afcoo/tap/thrurndis
 ## How to Use
 
 1. **Install VM Assets:** Install the latest compatible VM Assets during onboarding or in Settings.
-2. **Pass through the USB device:** In **Virtual Machine Accessories** in the menu bar, connect the USB device to **ThruRNDIS**.
+2. **USB device passthrough:** In **Virtual Machine Accessories** in the menu bar, connect the USB device to **ThruRNDIS**.
 
    ![Passing a USB device to ThruRNDIS from Virtual Machine Accessories](./images/accessory-access-onboarding.gif)
 


### PR DESCRIPTION
## Summary

Update the English and Korean READMEs for the managed VZNAT host-routing architecture introduced by #16.

## Changes

- Update permission requirements and the USB passthrough workflow.
- Add the optional port-forwarding setup step.
- Replace the WireGuard data-path description with the Bond, feth pair, VZNAT bridge, VM forwarding, and USB RNDIS path.
- Keep the English and Korean documentation aligned.

## Related issue

Depends on #16. Merge after that pull request.

## Validation

- [ ] ./script/build_and_run.sh --verify
- [ ] Checks run and unverified runtime paths are documented
- [ ] Signed Runtime validation with ./script/build_and_install.sh
- [ ] Real USB/VZNAT route validation
- [x] Not applicable; README-only changes. The English and Korean diffs were reviewed against origin/main.

## User-facing impact

The setup instructions and architecture overview change in README.md and README.ko.md. There is no app UI or runtime behavior change.

## Security and architecture

Documentation only. The READMEs describe the architecture implemented by #16; this pull request does not change runtime security behavior.

## Checklist

- [x] The pull request has one focused purpose.
- [x] The title follows Conventional Commits.
- [x] Behavior changes include appropriate build or runtime validation, with unavailable paths explained.
- [x] User-facing behavior and operational changes are documented.
- [x] New, moved, renamed, or deleted Swift files are reflected in Xcode groups, target membership, and build phases; no Swift files changed.
- [x] No credentials, provisioning profiles, personal signing values, or local build artifacts are included.
- [x] Guest VM scripts and VM Asset build tooling remain in Afcoo/ThruRNDIS_VM_Assets.