### PR TITLE
feat(usb): improve accessory selection and replacement

### DIFF
--- a/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
@@ -42,28 +42,10 @@ private enum VMRestartWorkflowRequest {
     case manual
     case accessoryReplacement(accessoryID: UInt64)
 
-    var attachmentAccessoryID: UInt64? {
-        switch self {
-        case .manual:
-            nil
-        case .accessoryReplacement(let accessoryID):
-            accessoryID
-        }
-    }
-
-    var networkStopReason: String {
+    var reason: String {
         switch self {
         case .manual:
             "VM restart"
-        case .accessoryReplacement:
-            "USB accessory replacement"
-        }
-    }
-
-    var vmRestartReason: String {
-        switch self {
-        case .manual:
-            "manual request"
         case .accessoryReplacement:
             "USB accessory replacement"
         }
@@ -190,7 +172,7 @@ final class TetheringWorkflowCoordinator {
         Task { @MainActor [weak self] in
             guard let self else { return }
             let didStopVMNetwork = await self.actions.stopNetworkRouting(
-                request.networkStopReason
+                request.reason
             )
             guard didStopVMNetwork else {
                 self.appendEventLog(
@@ -210,79 +192,45 @@ final class TetheringWorkflowCoordinator {
                 self.setVMRestartState(.idle)
                 return
             }
-            if let attachmentAccessoryID = request.attachmentAccessoryID {
-                self.prepareAttachmentForVMRestart(
-                    accessoryID: attachmentAccessoryID
-                )
-            }
             self.usbCoordinator.prepareForIntentionalVMStop()
             self.vmCoordinator.restart(
-                reason: request.vmRestartReason
+                reason: request.reason
             ) { [weak self] in
                 guard let self else { return }
                 self.setVMRestartState(.starting)
-                guard self.preparePendingAttachmentForRestartedVM(
-                    expectedAccessoryID: request.attachmentAccessoryID
-                ) else {
+                guard self.continueVMRestart(request) else {
                     self.setVMRestartState(.idle)
                     return
-                }
-                if self.actions.startVirtualMachine() {
-                    if self.hasPendingAttachment,
-                       self.runtimeState == .starting {
-                        self.markVMStartedForPendingAttachment()
-                    }
-                } else {
-                    self.setVMRestartState(.idle)
-                    self.cancelWorkflow(
-                        reason: "VM preflight failed after restart"
-                    )
                 }
             }
         }
     }
 
-    private func prepareAttachmentForVMRestart(accessoryID: UInt64) {
-        setAttachmentState(
-            .waitingForVMStop(
-                PendingUSBAttachment(
-                    accessoryID: accessoryID,
-                    token: UUID(),
-                    startedVM: false
-                )
-            )
-        )
-    }
-
-    private func preparePendingAttachmentForRestartedVM(
-        expectedAccessoryID: UInt64?
+    private func continueVMRestart(
+        _ request: VMRestartWorkflowRequest
     ) -> Bool {
-        guard let expectedAccessoryID else {
+        switch request {
+        case .manual:
             guard attachmentState == .idle else {
                 cancelPendingAttachment(
                     reason: "unexpected pending USB attachment during targetless VM restart"
                 )
                 return false
             }
+            return actions.startVirtualMachine()
+        case .accessoryReplacement(let accessoryID):
+            guard beginAttachmentWorkflow(accessoryID: accessoryID) != nil else {
+                appendEventLog(
+                    "USB accessory replacement failed for registry " +
+                        Self.registryIDText(accessoryID) +
+                        " after VM restart.",
+                    level: .warning,
+                    category: .usb
+                )
+                return false
+            }
             return true
         }
-
-        guard pendingAttachmentAccessoryID == expectedAccessoryID,
-              let attachment = attachmentState.attachment,
-              usbSession.accessories.contains(
-                where: { $0.id == expectedAccessoryID }
-              ) else {
-            cancelPendingAttachment(
-                reason: "expected USB accessory unavailable during VM restart"
-            )
-            actions.updateStatusMessage(
-                String(localized: "The USB accessory became unavailable before it could be attached.")
-            )
-            return false
-        }
-
-        setAttachmentState(.waitingForVM(attachment))
-        return true
     }
 
     private func markVMStartedForPendingAttachment() {

--- a/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
@@ -103,12 +103,12 @@ final class TetheringWorkflowCoordinator {
         presentNextUSBAttachmentPromptIfPossible()
     }
 
-    func prepareForManualVMRestart(attachedAccessoryID: UInt64?) {
-        guard let attachedAccessoryID else { return }
+    func prepareForVMRestart(attachingAccessoryID: UInt64?) {
+        guard let attachingAccessoryID else { return }
         setAttachmentState(
             .waitingForVMStop(
                 PendingUSBAttachment(
-                    accessoryID: attachedAccessoryID,
+                    accessoryID: attachingAccessoryID,
                     token: UUID(),
                     startedVM: false
                 )
@@ -116,14 +116,26 @@ final class TetheringWorkflowCoordinator {
         )
     }
 
-    func canStartVMForManualRestart() -> Bool {
-        guard let accessoryID = pendingAttachmentAccessoryID else {
+    func preparePendingAttachmentForRestartedVM(
+        expectedAccessoryID: UInt64?
+    ) -> Bool {
+        guard let expectedAccessoryID else {
+            guard attachmentState == .idle else {
+                cancelPendingAttachment(
+                    reason: "unexpected pending USB attachment during targetless VM restart"
+                )
+                return false
+            }
             return true
         }
-        guard usbSession.accessories.contains(where: { $0.id == accessoryID })
-        else {
+
+        guard pendingAttachmentAccessoryID == expectedAccessoryID,
+              let attachment = attachmentState.attachment,
+              usbSession.accessories.contains(
+                where: { $0.id == expectedAccessoryID }
+              ) else {
             cancelPendingAttachment(
-                reason: "target USB accessory disconnected during VM restart"
+                reason: "expected USB accessory unavailable during VM restart"
             )
             actions.updateStatusMessage(
                 String(localized: "The USB accessory became unavailable before it could be attached.")
@@ -131,9 +143,7 @@ final class TetheringWorkflowCoordinator {
             return false
         }
 
-        if let attachment = attachmentState.attachment {
-            setAttachmentState(.waitingForVM(attachment))
-        }
+        setAttachmentState(.waitingForVM(attachment))
         return true
     }
 

--- a/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
@@ -51,13 +51,6 @@ private enum VMRestartWorkflowRequest {
         }
     }
 
-    var replacementAccessoryID: UInt64? {
-        guard case .accessoryReplacement(let accessoryID) = self else {
-            return nil
-        }
-        return accessoryID
-    }
-
     var networkStopReason: String {
         switch self {
         case .manual:
@@ -219,18 +212,6 @@ final class TetheringWorkflowCoordinator {
                 self.setVMRestartState(.idle)
                 return
             }
-            if let replacementAccessoryID = request.replacementAccessoryID,
-               !self.usbCoordinator.canUseAccessoryForAttachment(
-                   replacementAccessoryID
-               ) {
-                self.rejectAccessoryReplacement(
-                    replacementAccessoryID,
-                    reason: "target became unavailable during Network Routing cleanup"
-                )
-                self.setVMRestartState(.idle)
-                return
-            }
-
             self.prepareForVMRestart(
                 attachingAccessoryID: request.attachingAccessoryID
             )

--- a/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
@@ -223,7 +223,7 @@ final class TetheringWorkflowCoordinator {
                 appendEventLog(
                     "USB accessory replacement failed for registry " +
                         Self.registryIDText(accessoryID) +
-                        " after VM restart.",
+                        ": attachment could not start after the previous VM stopped.",
                     level: .warning,
                     category: .usb
                 )

--- a/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
@@ -242,7 +242,7 @@ final class TetheringWorkflowCoordinator {
         reason: String
     ) {
         actions.updateStatusMessage(
-            String(localized: "USB accessory replacement is no longer available.")
+            String(localized: "Unable to replace the USB device.")
         )
         appendEventLog(
             "USB accessory replacement rejected for registry " +

--- a/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
@@ -39,13 +39,13 @@ private enum VMRestartWorkflowState: Equatable {
 }
 
 private enum VMRestartWorkflowRequest {
-    case manual(attachingAccessoryID: UInt64?)
+    case manual
     case accessoryReplacement(accessoryID: UInt64)
 
-    var attachingAccessoryID: UInt64? {
+    var attachmentAccessoryID: UInt64? {
         switch self {
-        case .manual(let attachingAccessoryID):
-            attachingAccessoryID
+        case .manual:
+            nil
         case .accessoryReplacement(let accessoryID):
             accessoryID
         }
@@ -152,10 +152,8 @@ final class TetheringWorkflowCoordinator {
         presentNextUSBAttachmentPromptIfPossible()
     }
 
-    func restartVirtualMachine(attachingAccessoryID: UInt64?) {
-        restartVirtualMachine(
-            for: .manual(attachingAccessoryID: attachingAccessoryID)
-        )
+    func restartVirtualMachine() {
+        restartVirtualMachine(for: .manual)
     }
 
     func replaceAttachedAccessory(
@@ -212,9 +210,11 @@ final class TetheringWorkflowCoordinator {
                 self.setVMRestartState(.idle)
                 return
             }
-            self.prepareForVMRestart(
-                attachingAccessoryID: request.attachingAccessoryID
-            )
+            if let attachmentAccessoryID = request.attachmentAccessoryID {
+                self.prepareAttachmentForVMRestart(
+                    accessoryID: attachmentAccessoryID
+                )
+            }
             self.usbCoordinator.prepareForIntentionalVMStop()
             self.vmCoordinator.restart(
                 reason: request.vmRestartReason
@@ -222,7 +222,7 @@ final class TetheringWorkflowCoordinator {
                 guard let self else { return }
                 self.setVMRestartState(.starting)
                 guard self.preparePendingAttachmentForRestartedVM(
-                    expectedAccessoryID: request.attachingAccessoryID
+                    expectedAccessoryID: request.attachmentAccessoryID
                 ) else {
                     self.setVMRestartState(.idle)
                     return
@@ -242,12 +242,11 @@ final class TetheringWorkflowCoordinator {
         }
     }
 
-    private func prepareForVMRestart(attachingAccessoryID: UInt64?) {
-        guard let attachingAccessoryID else { return }
+    private func prepareAttachmentForVMRestart(accessoryID: UInt64) {
         setAttachmentState(
             .waitingForVMStop(
                 PendingUSBAttachment(
-                    accessoryID: attachingAccessoryID,
+                    accessoryID: accessoryID,
                     token: UUID(),
                     startedVM: false
                 )

--- a/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
@@ -32,10 +32,57 @@ private enum USBAttachmentWorkflowState: Equatable {
     }
 }
 
+private enum VMRestartWorkflowState: Equatable {
+    case idle
+    case stopping
+    case starting
+}
+
+private enum VMRestartWorkflowRequest {
+    case manual(attachingAccessoryID: UInt64?)
+    case accessoryReplacement(accessoryID: UInt64)
+
+    var attachingAccessoryID: UInt64? {
+        switch self {
+        case .manual(let attachingAccessoryID):
+            attachingAccessoryID
+        case .accessoryReplacement(let accessoryID):
+            accessoryID
+        }
+    }
+
+    var replacementAccessoryID: UInt64? {
+        guard case .accessoryReplacement(let accessoryID) = self else {
+            return nil
+        }
+        return accessoryID
+    }
+
+    var networkStopReason: String {
+        switch self {
+        case .manual:
+            "VM restart"
+        case .accessoryReplacement:
+            "USB accessory replacement"
+        }
+    }
+
+    var vmRestartReason: String {
+        switch self {
+        case .manual:
+            "manual request"
+        case .accessoryReplacement:
+            "USB accessory replacement"
+        }
+    }
+}
+
 @MainActor
 final class TetheringWorkflowCoordinator {
     struct Actions {
         let canPresentUSBAttachmentPrompt: () -> Bool
+        let canContinueVMRestart: () -> Bool
+        let stopNetworkRouting: (String) async -> Bool
         let startVirtualMachine: () -> Bool
         let updateStatusMessage: (String) -> Void
         let workflowStateDidChange: () -> Void
@@ -50,6 +97,7 @@ final class TetheringWorkflowCoordinator {
 
     private var runtimeState: VMRuntimeState
     private var attachmentState: USBAttachmentWorkflowState = .idle
+    private var vmRestartState: VMRestartWorkflowState = .idle
 
     init(
         assetProvider: VMAssetProviding,
@@ -74,6 +122,14 @@ final class TetheringWorkflowCoordinator {
 
     var attachmentRequiresVMStopRetry: Bool {
         runtimeState == .failed && vmCoordinator.hasVirtualMachine
+    }
+
+    var isRestartingVirtualMachine: Bool {
+        vmRestartState != .idle
+    }
+
+    var isStoppingForVMRestart: Bool {
+        vmRestartState == .stopping
     }
 
     func requestAttachAccessory(id accessoryID: UInt64) {
@@ -103,7 +159,109 @@ final class TetheringWorkflowCoordinator {
         presentNextUSBAttachmentPromptIfPossible()
     }
 
-    func prepareForVMRestart(attachingAccessoryID: UInt64?) {
+    func restartVirtualMachine(attachingAccessoryID: UInt64?) {
+        restartVirtualMachine(
+            for: .manual(attachingAccessoryID: attachingAccessoryID)
+        )
+    }
+
+    func replaceAttachedAccessory(
+        with accessoryID: UInt64,
+        prerequisitesSatisfied: Bool
+    ) {
+        guard prerequisitesSatisfied else {
+            rejectAccessoryReplacement(
+                accessoryID,
+                reason: "replacement prerequisites are no longer satisfied"
+            )
+            return
+        }
+
+        restartVirtualMachine(
+            for: .accessoryReplacement(accessoryID: accessoryID)
+        )
+    }
+
+    private func restartVirtualMachine(
+        for request: VMRestartWorkflowRequest
+    ) {
+        guard vmRestartState == .idle,
+              attachmentState == .idle,
+              vmCoordinator.canRestart else {
+            return
+        }
+
+        setVMRestartState(.stopping)
+        actions.updateStatusMessage(
+            String(localized: "Stopping Network Routing before restarting the VM.")
+        )
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let didStopVMNetwork = await self.actions.stopNetworkRouting(
+                request.networkStopReason
+            )
+            guard didStopVMNetwork else {
+                self.appendEventLog(
+                    "VM restart was cancelled because Network Routing cleanup failed.",
+                    level: .error,
+                    category: .network
+                )
+                self.actions.updateStatusMessage(
+                    String(localized: "Could not stop Network Routing. Retry Restart after resolving the Network Routing error.")
+                )
+                self.setVMRestartState(.idle)
+                return
+            }
+            guard self.actions.canContinueVMRestart(),
+                  self.vmRestartState == .stopping,
+                  self.vmCoordinator.canRestart else {
+                self.setVMRestartState(.idle)
+                return
+            }
+            if let replacementAccessoryID = request.replacementAccessoryID,
+               !self.usbCoordinator.canUseAccessoryForAttachment(
+                   replacementAccessoryID
+               ) {
+                self.rejectAccessoryReplacement(
+                    replacementAccessoryID,
+                    reason: "target became unavailable during Network Routing cleanup"
+                )
+                self.setVMRestartState(.idle)
+                return
+            }
+
+            self.prepareForVMRestart(
+                attachingAccessoryID: request.attachingAccessoryID
+            )
+            self.usbCoordinator.prepareForIntentionalVMStop()
+            self.vmCoordinator.restart(
+                reason: request.vmRestartReason
+            ) { [weak self] in
+                guard let self else { return }
+                self.setVMRestartState(.starting)
+                guard self.preparePendingAttachmentForRestartedVM(
+                    expectedAccessoryID: request.attachingAccessoryID
+                ) else {
+                    self.setVMRestartState(.idle)
+                    return
+                }
+                if self.actions.startVirtualMachine() {
+                    if self.hasPendingAttachment,
+                       self.runtimeState == .starting {
+                        self.markVMStartedForPendingAttachment()
+                    }
+                } else {
+                    self.setVMRestartState(.idle)
+                    self.cancelWorkflow(
+                        reason: "VM preflight failed after restart"
+                    )
+                }
+            }
+        }
+    }
+
+    private func prepareForVMRestart(attachingAccessoryID: UInt64?) {
         guard let attachingAccessoryID else { return }
         setAttachmentState(
             .waitingForVMStop(
@@ -116,7 +274,7 @@ final class TetheringWorkflowCoordinator {
         )
     }
 
-    func preparePendingAttachmentForRestartedVM(
+    private func preparePendingAttachmentForRestartedVM(
         expectedAccessoryID: UInt64?
     ) -> Bool {
         guard let expectedAccessoryID else {
@@ -147,11 +305,30 @@ final class TetheringWorkflowCoordinator {
         return true
     }
 
-    func markVMStartedForPendingAttachment() {
+    private func markVMStartedForPendingAttachment() {
         updatePendingAttachment { $0.startedVM = true }
     }
 
+    private func rejectAccessoryReplacement(
+        _ accessoryID: UInt64,
+        reason: String
+    ) {
+        actions.updateStatusMessage(
+            String(localized: "USB accessory replacement is no longer available.")
+        )
+        appendEventLog(
+            "USB accessory replacement rejected for registry " +
+                Self.registryIDText(accessoryID) +
+                ": \(reason).",
+            level: .warning,
+            category: .usb
+        )
+    }
+
     func vmStateDidChange(_ state: VMRuntimeState) {
+        if state == .running || state == .failed {
+            setVMRestartState(.idle)
+        }
         runtimeState = state
         switch state {
         case .running:
@@ -164,7 +341,8 @@ final class TetheringWorkflowCoordinator {
         }
     }
 
-    func vmDidStop(restartWillStartVM: Bool) {
+    func vmDidStop() {
+        let restartWillStartVM = isStoppingForVMRestart
         appendEventLog(
             "VM stop workflow snapshot: pendingUSB=" +
                 "\(pendingAttachmentAccessoryID.map(Self.registryIDText) ?? "none"), " +
@@ -266,6 +444,7 @@ final class TetheringWorkflowCoordinator {
             hasConfiguredVMAssets: assetProvider.hasConfiguredAssets,
             canPresent: actions.canPresentUSBAttachmentPrompt()
                 && attachmentState == .idle
+                && !isStoppingForVMRestart
                 && !assetProvider.isBusy
         )
     }
@@ -480,6 +659,12 @@ final class TetheringWorkflowCoordinator {
     private func setAttachmentState(_ state: USBAttachmentWorkflowState) {
         guard attachmentState != state else { return }
         attachmentState = state
+        actions.workflowStateDidChange()
+    }
+
+    private func setVMRestartState(_ state: VMRestartWorkflowState) {
+        guard vmRestartState != state else { return }
+        vmRestartState = state
         actions.workflowStateDidChange()
     }
 

--- a/ThruRNDIS/Coordinators/USBAccessoryCoordinator.swift
+++ b/ThruRNDIS/Coordinators/USBAccessoryCoordinator.swift
@@ -67,11 +67,17 @@ final class USBAccessoryCoordinator {
     }
 
     func canRequestAttachment(for accessoryID: UInt64) -> Bool {
+        guard vmSessionAccessoryID == nil else {
+            return false
+        }
+        return canUseAccessoryForAttachment(accessoryID)
+    }
+
+    func canUseAccessoryForAttachment(_ accessoryID: UInt64) -> Bool {
         guard let record = accessories.first(where: { $0.id == accessoryID }),
               record.hasConfigurationDescriptor,
               accessoryObjects[accessoryID] != nil,
               pendingAttachAccessoryID == nil,
-              vmSessionAccessoryID == nil,
               attachedAccessoryID != accessoryID else {
             return false
         }

--- a/ThruRNDIS/Coordinators/VMCoordinator.swift
+++ b/ThruRNDIS/Coordinators/VMCoordinator.swift
@@ -238,7 +238,7 @@ final class VMCoordinator {
         restartContinuation = startAgain
         transition(to: .stopping, message: String(localized: "Restarting VM."))
         reportEventLog(
-            "Restarting VM to recreate the fixed usb0 RNDIS session (\(reason)).",
+            "Restarting VM (\(reason)).",
             level: .info
         )
 

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -223,16 +223,6 @@
         }
       }
     },
-    "Attach Selected" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선택 항목 연결"
-          }
-        }
-      }
-    },
     "Attach USB" : {
       "localizations" : {
         "ko" : {
@@ -259,6 +249,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "연결됨"
+          }
+        }
+      }
+    },
+    "Available" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 가능"
           }
         }
       }
@@ -429,6 +429,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "선택…"
+          }
+        }
+      }
+    },
+    "Class" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클래스"
           }
         }
       }
@@ -699,6 +709,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "USB 연결 해제"
+          }
+        }
+      }
+    },
+    "Device" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기기"
           }
         }
       }
@@ -1551,6 +1571,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "관리형 저장소 외부의 VM 에셋 경로는 변경할 수 없습니다: %@"
+          }
+        }
+      }
+    },
+    "Registry" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "레지스트리"
           }
         }
       }
@@ -2499,6 +2529,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "버전"
+          }
+        }
+      }
+    },
+    "VID:PID" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VID:PID"
           }
         }
       }

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -683,6 +683,16 @@
         }
       }
     },
+    "Detach and Attach" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연결 해제 후 연결"
+          }
+        }
+      }
+    },
     "Detach the current USB accessory before attaching another USB accessory." : {
       "localizations" : {
         "ko" : {
@@ -1595,6 +1605,16 @@
         }
       }
     },
+    "Replace Attached USB Device?" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연결된 USB 기기를 교체할까요?"
+          }
+        }
+      }
+    },
     "Replay" : {
       "localizations" : {
         "ko" : {
@@ -2011,6 +2031,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SwiftTerm"
+          }
+        }
+      }
+    },
+    "The attached USB device will be detached, and the selected device will be attached." : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 연결된 USB 기기의 연결을 해제하고 선택한 기기를 연결합니다."
           }
         }
       }

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -253,16 +253,6 @@
         }
       }
     },
-    "Available" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사용 가능"
-          }
-        }
-      }
-    },
     "Available devices" : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -2403,6 +2403,16 @@
         }
       }
     },
+    "USB accessory replacement is no longer available." : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB 기기 교체 조건이 더 이상 충족되지 않습니다."
+          }
+        }
+      }
+    },
     "USB attach cooling down." : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -1265,16 +1265,6 @@
         }
       }
     },
-    "New devices require approval, and only one USB device can be attached during a VM session." : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새 기기는 승인이 필요하며, 한 VM 세션에는 USB 기기 한 대만 연결할 수 있습니다."
-          }
-        }
-      }
-    },
     "No events." : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -2393,12 +2393,12 @@
         }
       }
     },
-    "USB accessory replacement is no longer available." : {
+    "Unable to replace the USB device." : {
       "localizations" : {
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "USB 기기 교체 조건이 더 이상 충족되지 않습니다."
+            "value" : "USB 기기를 교체할 수 없습니다."
           }
         }
       }

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -618,6 +618,7 @@ final class TetheringStore: ObservableObject {
     func restartVirtualMachine() {
         restartVirtualMachine(
             attachingAccessoryID: attachedAccessoryID,
+            replacementAccessoryID: nil,
             networkStopReason: "VM restart",
             vmRestartReason: "manual request"
         )
@@ -626,21 +627,16 @@ final class TetheringStore: ObservableObject {
     func replaceAttachedAccessory(with accessoryID: UInt64) {
         refreshRuntimeEntitlements()
         guard canReplaceAttachedAccessory(with: accessoryID) else {
-            statusMessage = String(
-                localized: "USB accessory replacement is no longer available."
-            )
-            appendEventLog(
-                "USB accessory replacement rejected for registry 0x" +
-                    String(accessoryID, radix: 16, uppercase: true) +
-                    ": replacement prerequisites are no longer satisfied.",
-                level: .warning,
-                category: .usb
+            rejectAccessoryReplacement(
+                accessoryID,
+                reason: "replacement prerequisites are no longer satisfied"
             )
             return
         }
 
         restartVirtualMachine(
             attachingAccessoryID: accessoryID,
+            replacementAccessoryID: accessoryID,
             networkStopReason: "USB accessory replacement",
             vmRestartReason: "USB accessory replacement"
         )
@@ -648,6 +644,7 @@ final class TetheringStore: ObservableObject {
 
     private func restartVirtualMachine(
         attachingAccessoryID: UInt64?,
+        replacementAccessoryID: UInt64?,
         networkStopReason: String,
         vmRestartReason: String
     ) {
@@ -680,6 +677,17 @@ final class TetheringStore: ObservableObject {
                 self.vmRestartState = .idle
                 return
             }
+            if let replacementAccessoryID,
+               !self.usbCoordinator.canUseAccessoryForAttachment(
+                   replacementAccessoryID
+               ) {
+                self.rejectAccessoryReplacement(
+                    replacementAccessoryID,
+                    reason: "target became unavailable during Network Routing cleanup"
+                )
+                self.vmRestartState = .idle
+                return
+            }
 
             self.workflowCoordinator.prepareForVMRestart(
                 attachingAccessoryID: attachingAccessoryID
@@ -707,6 +715,22 @@ final class TetheringStore: ObservableObject {
                 }
             }
         }
+    }
+
+    private func rejectAccessoryReplacement(
+        _ accessoryID: UInt64,
+        reason: String
+    ) {
+        statusMessage = String(
+            localized: "USB accessory replacement is no longer available."
+        )
+        appendEventLog(
+            "USB accessory replacement rejected for registry 0x" +
+                String(accessoryID, radix: 16, uppercase: true) +
+                ": \(reason).",
+            level: .warning,
+            category: .usb
+        )
     }
 
     func requestAttachSelectedAccessory() {

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -626,7 +626,9 @@ final class TetheringStore: ObservableObject {
     func replaceAttachedAccessory(with accessoryID: UInt64) {
         refreshRuntimeEntitlements()
         guard canReplaceAttachedAccessory(with: accessoryID) else {
-            statusMessage = String(localized: "Wait for the current operation to finish.")
+            statusMessage = String(
+                localized: "USB accessory replacement is no longer available."
+            )
             appendEventLog(
                 "USB accessory replacement rejected for registry 0x" +
                     String(accessoryID, radix: 16, uppercase: true) +

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -627,6 +627,13 @@ final class TetheringStore: ObservableObject {
         refreshRuntimeEntitlements()
         guard canReplaceAttachedAccessory(with: accessoryID) else {
             statusMessage = String(localized: "Wait for the current operation to finish.")
+            appendEventLog(
+                "USB accessory replacement rejected for registry 0x" +
+                    String(accessoryID, radix: 16, uppercase: true) +
+                    ": replacement prerequisites are no longer satisfied.",
+                level: .warning,
+                category: .usb
+            )
             return
         }
 

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -15,12 +15,6 @@ private enum TetheringApplicationState: Equatable {
     case terminating
 }
 
-private enum TetheringVMRestartState: Equatable {
-    case idle
-    case stopping
-    case starting
-}
-
 private enum AccessoryMonitoringConfigurationBlocker {
     case onboardingIncomplete
     case vmAssetsUnavailable
@@ -52,7 +46,6 @@ private enum AccessoryMonitoringConfigurationBlocker {
 @MainActor
 final class TetheringStore: ObservableObject {
     @Published private(set) var runtimeState: VMRuntimeState = .idle
-    @Published private var vmRestartState: TetheringVMRestartState = .idle
     @Published private var isVMStopPreparationInProgress = false
     @Published private(set) var statusMessage =
         String(localized: "Install or select VM assets to begin.")
@@ -92,7 +85,13 @@ final class TetheringStore: ObservableObject {
                 return self.acceptsNewWork
                     && !self.isResettingAppSettings
                     && !self.isOnboardingPresented
-                    && !self.restartWillStartVM
+            },
+            canContinueVMRestart: { [weak self] in
+                self?.acceptsNewWork == true
+            },
+            stopNetworkRouting: { [weak self] reason in
+                guard let self else { return false }
+                return await self.networkRoute.stopAndWait(reason: reason)
             },
             startVirtualMachine: { [weak self] in
                 self?.startVirtualMachine() == true
@@ -141,7 +140,7 @@ final class TetheringStore: ObservableObject {
     }
 
     var isRestartingVirtualMachine: Bool {
-        vmRestartState != .idle
+        workflowCoordinator.isRestartingVirtualMachine
     }
 
     var isResettingAppSettings: Bool {
@@ -154,10 +153,6 @@ final class TetheringStore: ObservableObject {
 
     private var isPreparingForApplicationTermination: Bool {
         applicationState == .terminating
-    }
-
-    private var restartWillStartVM: Bool {
-        vmRestartState == .stopping
     }
 
     var accessories: [USBAccessoryRecord] { usbSession.accessories }
@@ -184,7 +179,7 @@ final class TetheringStore: ObservableObject {
             && hasConfiguredVMAssets
             && !assetProvider.isBusy
             && !isVMStopPreparationInProgress
-            && vmRestartState == .idle
+            && !isRestartingVirtualMachine
             && !networkRoute.isOperationInProgress
             && networkRoute.snapshot?.state == .inactive
             && portForwarding.isReadyForVMStart
@@ -196,7 +191,7 @@ final class TetheringStore: ObservableObject {
             && hasConfiguredVMAssets
             && !assetProvider.isBusy
             && !isVMStopPreparationInProgress
-            && vmRestartState == .idle
+            && !isRestartingVirtualMachine
             && !workflowCoordinator.hasPendingAttachment
             && vmCoordinator.canRestart
     }
@@ -214,7 +209,7 @@ final class TetheringStore: ObservableObject {
         acceptsNewWork
             && !assetProvider.isBusy
             && !isVMStopPreparationInProgress
-            && vmRestartState == .idle
+            && !isRestartingVirtualMachine
             && !networkRoute.isOperationInProgress
     }
 
@@ -253,7 +248,7 @@ final class TetheringStore: ObservableObject {
     var canStopVirtualMachine: Bool {
         acceptsNewWork
             && !isVMStopPreparationInProgress
-            && vmRestartState == .idle
+            && !isRestartingVirtualMachine
             && vmCoordinator.canStop
     }
 
@@ -265,7 +260,7 @@ final class TetheringStore: ObservableObject {
         guard acceptsNewWork,
               !isOnboardingPresented,
               !isVMStopPreparationInProgress,
-              vmRestartState == .idle,
+              !isRestartingVirtualMachine,
               hasConfiguredVMAssets,
               isNetworkRouteHelperReady,
               !assetProvider.isBusy,
@@ -289,7 +284,7 @@ final class TetheringStore: ObservableObject {
     var canDetachAccessory: Bool {
         acceptsNewWork
             && !isVMStopPreparationInProgress
-            && vmRestartState == .idle
+            && !isRestartingVirtualMachine
             && usbCoordinator.canDetachAccessory(runtimeState: runtimeState)
     }
 
@@ -318,7 +313,7 @@ final class TetheringStore: ObservableObject {
     func canChooseAccessoryForAttachment(_ accessoryID: UInt64) -> Bool {
         acceptsNewWork
             && !isVMStopPreparationInProgress
-            && vmRestartState == .idle
+            && !isRestartingVirtualMachine
             && isNetworkRouteHelperReady
             && !workflowCoordinator.hasPendingAttachment
             && usbAttachmentPrompt == nil
@@ -442,7 +437,7 @@ final class TetheringStore: ObservableObject {
         }
         guard !isVMStopPreparationInProgress,
               !networkRoute.isOperationInProgress,
-              vmRestartState == .idle || vmRestartState == .starting else {
+              !workflowCoordinator.isStoppingForVMRestart else {
             statusMessage = String(
                 localized: "Wait for Network Routing cleanup to finish before starting the VM."
             )
@@ -578,7 +573,7 @@ final class TetheringStore: ObservableObject {
     ) {
         guard acceptsNewWork,
               !isVMStopPreparationInProgress,
-              vmRestartState == .idle else {
+              !isRestartingVirtualMachine else {
             return
         }
 
@@ -616,120 +611,19 @@ final class TetheringStore: ObservableObject {
     }
 
     func restartVirtualMachine() {
-        restartVirtualMachine(
-            attachingAccessoryID: attachedAccessoryID,
-            replacementAccessoryID: nil,
-            networkStopReason: "VM restart",
-            vmRestartReason: "manual request"
+        guard canRestartVirtualMachine else { return }
+        workflowCoordinator.restartVirtualMachine(
+            attachingAccessoryID: attachedAccessoryID
         )
     }
 
     func replaceAttachedAccessory(with accessoryID: UInt64) {
         refreshRuntimeEntitlements()
-        guard canReplaceAttachedAccessory(with: accessoryID) else {
-            rejectAccessoryReplacement(
-                accessoryID,
-                reason: "replacement prerequisites are no longer satisfied"
+        workflowCoordinator.replaceAttachedAccessory(
+            with: accessoryID,
+            prerequisitesSatisfied: canReplaceAttachedAccessory(
+                with: accessoryID
             )
-            return
-        }
-
-        restartVirtualMachine(
-            attachingAccessoryID: accessoryID,
-            replacementAccessoryID: accessoryID,
-            networkStopReason: "USB accessory replacement",
-            vmRestartReason: "USB accessory replacement"
-        )
-    }
-
-    private func restartVirtualMachine(
-        attachingAccessoryID: UInt64?,
-        replacementAccessoryID: UInt64?,
-        networkStopReason: String,
-        vmRestartReason: String
-    ) {
-        guard canRestartVirtualMachine else { return }
-        vmRestartState = .stopping
-        statusMessage = String(
-            localized: "Stopping Network Routing before restarting the VM."
-        )
-
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            let didStopVMNetwork = await self.networkRoute.stopAndWait(
-                reason: networkStopReason
-            )
-            guard didStopVMNetwork else {
-                self.appendEventLog(
-                    "VM restart was cancelled because Network Routing cleanup failed.",
-                    level: .error,
-                    category: .network
-                )
-                self.statusMessage = String(
-                    localized: "Could not stop Network Routing. Retry Restart after resolving the Network Routing error."
-                )
-                self.vmRestartState = .idle
-                return
-            }
-            guard self.acceptsNewWork,
-                  self.vmRestartState == .stopping,
-                  self.vmCoordinator.canRestart else {
-                self.vmRestartState = .idle
-                return
-            }
-            if let replacementAccessoryID,
-               !self.usbCoordinator.canUseAccessoryForAttachment(
-                   replacementAccessoryID
-               ) {
-                self.rejectAccessoryReplacement(
-                    replacementAccessoryID,
-                    reason: "target became unavailable during Network Routing cleanup"
-                )
-                self.vmRestartState = .idle
-                return
-            }
-
-            self.workflowCoordinator.prepareForVMRestart(
-                attachingAccessoryID: attachingAccessoryID
-            )
-            self.usbCoordinator.prepareForIntentionalVMStop()
-            self.vmCoordinator.restart(reason: vmRestartReason) { [weak self] in
-                guard let self else { return }
-                self.vmRestartState = .starting
-                guard self.workflowCoordinator.preparePendingAttachmentForRestartedVM(
-                    expectedAccessoryID: attachingAccessoryID
-                ) else {
-                    self.vmRestartState = .idle
-                    return
-                }
-                if self.startVirtualMachine() {
-                    if self.workflowCoordinator.hasPendingAttachment,
-                       self.runtimeState == .starting {
-                        self.workflowCoordinator.markVMStartedForPendingAttachment()
-                    }
-                } else {
-                    self.vmRestartState = .idle
-                    self.workflowCoordinator.cancelWorkflow(
-                        reason: "VM preflight failed after restart"
-                    )
-                }
-            }
-        }
-    }
-
-    private func rejectAccessoryReplacement(
-        _ accessoryID: UInt64,
-        reason: String
-    ) {
-        statusMessage = String(
-            localized: "USB accessory replacement is no longer available."
-        )
-        appendEventLog(
-            "USB accessory replacement rejected for registry 0x" +
-                String(accessoryID, radix: 16, uppercase: true) +
-                ": \(reason).",
-            level: .warning,
-            category: .usb
         )
     }
 
@@ -750,7 +644,7 @@ final class TetheringStore: ObservableObject {
     func requestAttachAccessory(id accessoryID: UInt64) {
         guard acceptsNewWork,
               !isVMStopPreparationInProgress,
-              vmRestartState == .idle else {
+              !isRestartingVirtualMachine else {
             return
         }
         refreshRuntimeEntitlements()
@@ -911,9 +805,6 @@ final class TetheringStore: ObservableObject {
     private func configureCoordinators() {
         vmCoordinator.onStateChange = { [weak self] state, message in
             guard let self else { return }
-            if state == .running || state == .failed {
-                self.vmRestartState = .idle
-            }
             self.runtimeState = state
             self.statusMessage = message
             if state == .failed {
@@ -947,9 +838,7 @@ final class TetheringStore: ObservableObject {
             guard let self else { return }
             self.networkRoute.vmDidStop()
             self.portForwarding.vmDidStop()
-            self.workflowCoordinator.vmDidStop(
-                restartWillStartVM: self.restartWillStartVM
-            )
+            self.workflowCoordinator.vmDidStop()
             self.syncUSBState()
         }
 

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -270,9 +270,17 @@ final class TetheringStore: ObservableObject {
               isNetworkRouteHelperReady,
               !assetProvider.isBusy,
               !workflowCoordinator.hasPendingAttachment,
-              vmSessionAccessoryID == nil,
               !workflowCoordinator.attachmentRequiresVMStopRetry,
-              let selectedAccessoryID else {
+              let selectedAccessoryID,
+              selectedAccessoryID != attachedAccessoryID else {
+            return false
+        }
+
+        if attachedAccessoryID != nil {
+            return canReplaceAttachedAccessory(with: selectedAccessoryID)
+        }
+
+        guard vmSessionAccessoryID == nil else {
             return false
         }
         return usbCoordinator.canRequestAttachment(for: selectedAccessoryID)
@@ -283,6 +291,28 @@ final class TetheringStore: ObservableObject {
             && !isVMStopPreparationInProgress
             && vmRestartState == .idle
             && usbCoordinator.canDetachAccessory(runtimeState: runtimeState)
+    }
+
+    var canDetachSelectedAccessory: Bool {
+        guard let selectedAccessoryID,
+              selectedAccessoryID == attachedAccessoryID else {
+            return false
+        }
+        return canDetachAccessory
+    }
+
+    private func canReplaceAttachedAccessory(with accessoryID: UInt64) -> Bool {
+        guard canRestartVirtualMachine,
+              !isOnboardingPresented,
+              isNetworkRouteHelperReady,
+              runtimeEntitlements.accessoryAccessUSB,
+              !workflowCoordinator.attachmentRequiresVMStopRetry,
+              let attachedAccessoryID,
+              attachedAccessoryID != accessoryID,
+              vmSessionAccessoryID == attachedAccessoryID else {
+            return false
+        }
+        return usbCoordinator.canUseAccessoryForAttachment(accessoryID)
     }
 
     func canChooseAccessoryForAttachment(_ accessoryID: UInt64) -> Bool {
@@ -586,6 +616,32 @@ final class TetheringStore: ObservableObject {
     }
 
     func restartVirtualMachine() {
+        restartVirtualMachine(
+            attachingAccessoryID: attachedAccessoryID,
+            networkStopReason: "VM restart",
+            vmRestartReason: "manual request"
+        )
+    }
+
+    func replaceAttachedAccessory(with accessoryID: UInt64) {
+        refreshRuntimeEntitlements()
+        guard canReplaceAttachedAccessory(with: accessoryID) else {
+            statusMessage = String(localized: "Wait for the current operation to finish.")
+            return
+        }
+
+        restartVirtualMachine(
+            attachingAccessoryID: accessoryID,
+            networkStopReason: "USB accessory replacement",
+            vmRestartReason: "USB accessory replacement"
+        )
+    }
+
+    private func restartVirtualMachine(
+        attachingAccessoryID: UInt64?,
+        networkStopReason: String,
+        vmRestartReason: String
+    ) {
         guard canRestartVirtualMachine else { return }
         vmRestartState = .stopping
         statusMessage = String(
@@ -595,7 +651,7 @@ final class TetheringStore: ObservableObject {
         Task { @MainActor [weak self] in
             guard let self else { return }
             let didStopVMNetwork = await self.networkRoute.stopAndWait(
-                reason: "VM restart"
+                reason: networkStopReason
             )
             guard didStopVMNetwork else {
                 self.appendEventLog(
@@ -616,14 +672,16 @@ final class TetheringStore: ObservableObject {
                 return
             }
 
-            self.workflowCoordinator.prepareForManualVMRestart(
-                attachedAccessoryID: self.attachedAccessoryID
+            self.workflowCoordinator.prepareForVMRestart(
+                attachingAccessoryID: attachingAccessoryID
             )
             self.usbCoordinator.prepareForIntentionalVMStop()
-            self.vmCoordinator.restart(reason: "manual request") { [weak self] in
+            self.vmCoordinator.restart(reason: vmRestartReason) { [weak self] in
                 guard let self else { return }
                 self.vmRestartState = .starting
-                guard self.workflowCoordinator.canStartVMForManualRestart() else {
+                guard self.workflowCoordinator.preparePendingAttachmentForRestartedVM(
+                    expectedAccessoryID: attachingAccessoryID
+                ) else {
                     self.vmRestartState = .idle
                     return
                 }

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -612,9 +612,7 @@ final class TetheringStore: ObservableObject {
 
     func restartVirtualMachine() {
         guard canRestartVirtualMachine else { return }
-        workflowCoordinator.restartVirtualMachine(
-            attachingAccessoryID: attachedAccessoryID
-        )
+        workflowCoordinator.restartVirtualMachine()
     }
 
     func replaceAttachedAccessory(with accessoryID: UInt64) {

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -8,6 +8,7 @@ struct USBDevicesView: View {
     @EnvironmentObject private var store: TetheringStore
     @EnvironmentObject private var usbSession: USBSessionStore
     @EnvironmentObject private var appPreferences: AppPreferencesStore
+    @State private var replacementConfirmation: USBAccessoryReplacementConfirmation?
 
     var body: some View {
         Form {
@@ -104,17 +105,48 @@ struct USBDevicesView: View {
                     Spacer()
 
                     Button("Attach") {
-                        store.requestAttachSelectedAccessory()
+                        requestSelectedAccessoryAttachment()
                     }
                     .disabled(!store.canAttachSelectedAccessory)
 
                     Button("Detach") {
                         store.detachAccessory()
                     }
-                    .disabled(!store.canDetachAccessory)
+                    .disabled(!store.canDetachSelectedAccessory)
                 }
             }
         }
+        .alert(item: $replacementConfirmation) { confirmation in
+            Alert(
+                title: Text("Replace Attached USB Device?"),
+                message: Text(
+                    "The attached USB device will be detached, and the selected device will be attached."
+                ),
+                primaryButton: .destructive(Text("Detach and Attach")) {
+                    store.replaceAttachedAccessory(
+                        with: confirmation.replacementAccessoryID
+                    )
+                },
+                secondaryButton: .cancel()
+            )
+        }
+    }
+
+    private func requestSelectedAccessoryAttachment() {
+        guard let selectedAccessoryID = usbSession.selectedAccessoryID else {
+            store.requestAttachSelectedAccessory()
+            return
+        }
+
+        if let attachedAccessoryID = usbSession.attachedAccessoryID,
+           attachedAccessoryID != selectedAccessoryID {
+            replacementConfirmation = USBAccessoryReplacementConfirmation(
+                replacementAccessoryID: selectedAccessoryID
+            )
+            return
+        }
+
+        store.requestAttachSelectedAccessory()
     }
 
     private var displayedAccessories: [USBAccessoryRecord] {
@@ -157,4 +189,10 @@ struct USBDevicesView: View {
 
         return usbSession.isAccessoryMonitoring ? .active : .stopped
     }
+}
+
+private struct USBAccessoryReplacementConfirmation: Identifiable {
+    let replacementAccessoryID: UInt64
+
+    var id: UInt64 { replacementAccessoryID }
 }

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -53,6 +53,26 @@ struct USBDevicesView: View {
             }
 
             Section("USB Devices") {
+                HStack {
+                    Toggle(
+                        "Ask to attach when device is available",
+                        isOn: $appPreferences.shouldAskToAttachDetectedUSBDevices
+                    )
+                    .toggleStyle(.checkbox)
+
+                    Spacer()
+
+                    Button("Attach") {
+                        requestSelectedAccessoryAttachment()
+                    }
+                    .disabled(!store.canAttachSelectedAccessory)
+
+                    Button("Detach") {
+                        store.detachAccessory()
+                    }
+                    .disabled(!store.canDetachSelectedAccessory)
+                }
+
                 Table(
                     displayedAccessories,
                     selection: selectedAccessoryBinding
@@ -92,26 +112,6 @@ struct USBDevicesView: View {
                     .width(100)
                 }
                 .frame(height: 180)
-
-                HStack {
-                    Toggle(
-                        "Ask to attach when device is available",
-                        isOn: $appPreferences.shouldAskToAttachDetectedUSBDevices
-                    )
-                    .toggleStyle(.checkbox)
-
-                    Spacer()
-
-                    Button("Attach") {
-                        requestSelectedAccessoryAttachment()
-                    }
-                    .disabled(!store.canAttachSelectedAccessory)
-
-                    Button("Detach") {
-                        store.detachAccessory()
-                    }
-                    .disabled(!store.canDetachSelectedAccessory)
-                }
             }
         }
         .alert(item: $replacementConfirmation) { confirmation in

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -55,19 +55,20 @@ struct USBDevicesView: View {
 
             Section("USB Devices") {
                 Table(
-                    usbSession.accessories,
+                    displayedAccessories,
                     selection: selectedAccessoryBinding
                 ) {
-                    TableColumn("Status") { accessory in
+                    TableColumn("") { accessory in
                         if accessory.id == usbSession.attachedAccessoryID {
-                            Text("Attached")
+                            Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .accessibilityLabel(Text("Attached"))
                         } else {
-                            Text("Available")
-                                .foregroundStyle(.secondary)
+                            EmptyView()
                         }
                     }
-                    .width(60)
+                    .width(20)
 
                     TableColumn("VID:PID") { accessory in
                         Text(verbatim: accessory.usbIDText)
@@ -80,7 +81,6 @@ struct USBDevicesView: View {
                         Text(verbatim: accessory.deviceName)
                             .lineLimit(1)
                     }
-                    .width(160)
 
                     TableColumn("Class") { accessory in
                         Text(verbatim: accessory.classText)
@@ -115,6 +115,22 @@ struct USBDevicesView: View {
                 }
             }
         }
+    }
+
+    private var displayedAccessories: [USBAccessoryRecord] {
+        let accessories = usbSession.accessories
+        guard let attachedAccessoryID = usbSession.attachedAccessoryID,
+              let attachedIndex = accessories.firstIndex(where: {
+                $0.id == attachedAccessoryID
+              }),
+              attachedIndex != accessories.startIndex else {
+            return accessories
+        }
+
+        var displayedAccessories = accessories
+        let attachedAccessory = displayedAccessories.remove(at: attachedIndex)
+        displayedAccessories.insert(attachedAccessory, at: 0)
+        return displayedAccessories
     }
 
     private var selectedAccessoryBinding: Binding<UInt64?> {

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -54,23 +54,56 @@ struct USBDevicesView: View {
             }
 
             Section("USB Devices") {
-                if usbSession.accessories.isEmpty {
-                    LabeledContent("Available devices", value: String(localized: "None"))
-                } else {
-                    List(selection: selectedAccessoryBinding) {
-                        ForEach(usbSession.accessories) { accessory in
-                            USBAccessoryRow(
-                                accessory: accessory,
-                                isAttached: accessory.id == usbSession.attachedAccessoryID
-                            )
-                            .tag(accessory.id)
+                Table(
+                    usbSession.accessories,
+                    selection: selectedAccessoryBinding
+                ) {
+                    TableColumn("Status") { accessory in
+                        if accessory.id == usbSession.attachedAccessoryID {
+                            Text("Attached")
+                                .foregroundStyle(.green)
+                        } else {
+                            Text("Available")
+                                .foregroundStyle(.secondary)
                         }
                     }
-                    .frame(height: 180)
+                    .width(60)
+
+                    TableColumn("VID:PID") { accessory in
+                        Text(verbatim: accessory.usbIDText)
+                            .monospaced()
+                            .lineLimit(1)
+                    }
+                    .width(90)
+
+                    TableColumn("Device") { accessory in
+                        Text(verbatim: accessory.deviceName)
+                            .lineLimit(1)
+                    }
+                    .width(160)
+
+                    TableColumn("Class") { accessory in
+                        Text(verbatim: accessory.classText)
+                    }
+                    .width(70)
+
+                    TableColumn("Registry") { accessory in
+                        Text(verbatim: accessory.registryIDText)
+                    }
+                    .width(100)
                 }
+                .frame(height: 180)
 
                 HStack {
-                    Button("Attach Selected") {
+                    Toggle(
+                        "Ask to attach when device is available",
+                        isOn: $appPreferences.shouldAskToAttachDetectedUSBDevices
+                    )
+                    .toggleStyle(.checkbox)
+
+                    Spacer()
+
+                    Button("Attach") {
                         store.requestAttachSelectedAccessory()
                     }
                     .disabled(!store.canAttachSelectedAccessory)
@@ -79,14 +112,6 @@ struct USBDevicesView: View {
                         store.detachAccessory()
                     }
                     .disabled(!store.canDetachAccessory)
-
-                    Spacer()
-
-                    Toggle(
-                        "Ask to attach when device is available",
-                        isOn: $appPreferences.shouldAskToAttachDetectedUSBDevices
-                    )
-                    .toggleStyle(.checkbox)
                 }
             }
         }
@@ -115,36 +140,5 @@ struct USBDevicesView: View {
         }
 
         return usbSession.isAccessoryMonitoring ? .active : .stopped
-    }
-}
-
-private struct USBAccessoryRow: View {
-    let accessory: USBAccessoryRecord
-    let isAttached: Bool
-
-    var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: isAttached ? "checkmark.circle.fill" : "cable.connector")
-                .foregroundStyle(isAttached ? .green : .secondary)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(verbatim: accessory.deviceName)
-                    .lineLimit(1)
-
-                Text("VID:PID \(accessory.usbIDText) · Class \(accessory.classText) · Registry \(accessory.registryIDText)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-
-            Spacer()
-
-            if isAttached {
-                Text("Attached")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .padding(.vertical, 2)
     }
 }

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -50,8 +50,6 @@ struct USBDevicesView: View {
                 }
             } header: {
                 Text("AccessoryAccess Listener")
-            } footer: {
-                Text("New devices require approval, and only one USB device can be attached during a VM session.")
             }
 
             Section("USB Devices") {


### PR DESCRIPTION
## Summary

Improves how USB accessories are presented and managed in Settings, including selection-aware actions and confirmed replacement of an attached accessory.

## Changes

- Replaces the USB accessory list with a fixed-height table showing status, VID:PID, device name, class, and registry ID.
- Pins the attached accessory to the first row and marks it with a green checkmark.
- Enables Attach and Detach according to the selected row's attachment state.
- Confirms replacement before detaching the current accessory, stopping its VM session, starting a new VM session, and attaching the selected accessory.
- Preserves the existing one-VM-boot-per-attachment lifecycle and validates the expected accessory before restarting.
- Logs and surfaces accessory replacement rejections.

## Related issue

None.

## Validation

- [ ] `./script/build_and_run.sh --verify` — not run because it terminates any currently running ThruRNDIS instance.
- [x] Checks run and unverified runtime paths are documented
  - `xcodebuild -project ThruRNDIS.xcodeproj -scheme ThruRNDIS -configuration Debug CODE_SIGNING_ALLOWED=NO build`
  - `xcodebuild -project ThruRNDIS.xcodeproj -list`
  - `plutil -lint` for the project, plists, and entitlements
  - scheme XML validation, string catalog validation, and `git diff --check`
- [ ] Signed Runtime validation with `./script/build_and_install.sh`
- [ ] Real USB/VZNAT route validation
- [x] Not applicable; explanation: signed Runtime and real USB/VZNAT validation require approved entitlements and physical hardware unavailable in this environment.

## User-facing impact

The USB Devices settings section now uses a table, clearly marks the attached device, derives action availability from the selected row, and asks for confirmation before replacing an attached device. No screenshot is included because an unsigned build cannot enumerate AccessoryAccess USB devices.

## Security and architecture

USB replacement reuses the existing managed-network cleanup and VM restart workflow so a new accessory is attached only in a new VM session. No privileged-helper, XPC, entitlement, host-route contract, VM Asset, security, or privacy changes are included.

## Checklist

- [x] The pull request has one focused purpose.
- [x] The title follows Conventional Commits.
- [x] Behavior changes include appropriate build or runtime validation, with unavailable paths explained.
- [x] User-facing behavior and operational changes are documented.
- [x] New, moved, renamed, or deleted Swift files are reflected in Xcode groups, target membership, and build phases. No Swift files were added, moved, renamed, or deleted.
- [x] No credentials, provisioning profiles, personal signing values, or local build artifacts are included.
- [x] Guest VM scripts and VM Asset build tooling remain in `Afcoo/ThruRNDIS_VM_Assets`.
