### PR TITLE
docs(build): clarify build number update rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,8 +260,14 @@ macOS 0.0.0.0/1 and 128.0.0.0/1 routes
   marketing/build versions, and has a code-signing identifier equal to its
   launchd `Label` and sole `MachServices` key. `BundleProgram` remains
   `Contents/MacOS/ThruRNDISPrivilegedHelper`.
-- Increment `CURRENT_PROJECT_VERSION` for every app update so a registered
-  older helper is replaced.
+- Treat `CURRENT_PROJECT_VERSION` as the identity of a distinct installed or
+  published app update, not as a build-invocation counter. Do not increment it
+  for repeated local builds, unsigned Debug builds, or test retries for the
+  same update. Increment it once when preparing a distinct signed app update
+  for installation or distribution so a registered older helper is replaced.
+  During same-build local signed iteration, manually Reinstall the Network
+  Helper after changing it; increment the build number only when specifically
+  validating automatic version-driven helper replacement.
 - Runtime and distribution validators must reject any embedded
   `.systemextension` and any obsolete network/system-extension entitlement.
 

--- a/Configuration/BuildSettings.xcconfig
+++ b/Configuration/BuildSettings.xcconfig
@@ -8,7 +8,8 @@ DEVELOPMENT_TEAM =
 THRURNDIS_APP_BUNDLE_IDENTIFIER = com.example.thrurndis
 THRURNDIS_PRIVILEGED_HELPER_BUNDLE_IDENTIFIER = $(THRURNDIS_APP_BUNDLE_IDENTIFIER).privileged-helper
 // The privileged helper uses the app-shared CFBundleVersion for automatic
-// upgrades. Increment CURRENT_PROJECT_VERSION for every app update.
+// upgrades. Increment CURRENT_PROJECT_VERSION once per distinct installed or
+// published app update, not for repeated local builds of the same update.
 THRURNDIS_APP_DISTRIBUTION_PROVISIONING_PROFILE =
 LOCALIZATION_PREFERS_STRING_CATALOGS = YES
 SWIFT_EMIT_LOC_STRINGS = YES


### PR DESCRIPTION
## Summary

- define CURRENT_PROJECT_VERSION as an installed or published update identity, not a build counter
- exempt repeated local, unsigned Debug, and same-update test builds from increments
- document manual Network Helper reinstall for same-build signed helper iteration
- align the shared build-settings comment with the repository guidance

## Validation

- git diff --check
- full build not run because only documentation and comments changed