### PR TITLE
fix(ui): clarify network start prompt

### DIFF
--- a/ThruRNDIS/Models/USBAttachmentPrompt.swift
+++ b/ThruRNDIS/Models/USBAttachmentPrompt.swift
@@ -26,7 +26,7 @@ struct USBAttachmentPrompt: Identifiable {
     var message: String {
         switch kind {
         case .attach:
-            return String(localized: "\(accessory.deviceName) has been connected.\nStart the VM and attach this device?")
+            return String(localized: "\(accessory.deviceName) has been connected.\nStart networking through this device?")
         case .assetsRequired:
             return String(localized: "\(accessory.deviceName) has been connected, but VM assets have not been configured.\nOpen Settings to install VM Assets.")
         }

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -63,12 +63,12 @@
         }
       }
     },
-    "%@ has been connected.\nStart the VM and attach this device?" : {
+    "%@ has been connected.\nStart networking through this device?" : {
       "localizations" : {
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ 기기가 연결되었습니다.\nVM을 시작하고 이 기기를 연결할까요?"
+            "value" : "%@ 기기가 연결되었습니다.\n이 기기로 네트워크를 연결할까요?"
           }
         }
       }


### PR DESCRIPTION
## Summary

Clarify the detected USB prompt so accepting it communicates that networking will start through the device instead of only mentioning VM attachment.

## Changes

- Update the English prompt to `Start networking through this device?`.
- Update the Korean prompt to `이 기기로 네트워크를 연결할까요?`.
- Keep USB attachment and automatic network-start behavior unchanged.

## Related issue

None.

## Validation

- [ ] `./script/build_and_run.sh --verify`
- [x] Checks run and unverified runtime paths are documented
- [ ] Signed Runtime validation with `./script/build_and_install.sh`
- [ ] Real USB/VZNAT route validation
- [x] Not applicable; explanation: runtime launch, signing, and real-device validation are unnecessary for this copy-only change.

Checks performed:

- String catalog JSON validation with `jq empty`
- Project, plist, and entitlement validation with `plutil -lint`
- Shared scheme XML validation with `xmllint --noout`
- Project and scheme discovery with `xcodebuild -list`
- Unsigned Debug build with `CODE_SIGNING_ALLOWED=NO` — succeeded

## User-facing impact

The USB approval prompt now states that accepting will start networking through the detected device. No screenshot is included because this is a copy-only change to the existing alert.

## Security and architecture

None. USB, VM lifecycle, host routes, privileged-helper behavior, signing, and VM Assets are unchanged.

## Checklist

- [x] The pull request has one focused purpose.
- [x] The title follows Conventional Commits, for example `fix(usb): serialize detach handling`.
- [x] Behavior changes include appropriate build or runtime validation, with unavailable paths explained.
- [x] User-facing behavior and operational changes are documented.
- [x] New, moved, renamed, or deleted Swift files are reflected in Xcode groups, target membership, and build phases.
- [x] No credentials, provisioning profiles, personal signing values, or local build artifacts are included.
- [x] Guest VM scripts and VM Asset build tooling remain in `Afcoo/ThruRNDIS_VM_Assets`.