### PR TITLE
feat(usb): add automatic device reattachment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,9 @@ macOS 0.0.0.0/1 and 128.0.0.0/1 routes
   app settings are reset, or the app terminates.
 - Outside debug mode, a successful USB passthrough attachment arms one automatic
   managed-network start. In debug mode, only an attachment accepted through the
-  detected-device prompt arms that start; attachments requested from the
-  Settings USB list or menu bar leave routing stopped for an explicit Start.
+  detected-device prompt arms that start; remembered Auto Connect attachments
+  and attachments requested from the Settings USB list or menu bar leave routing
+  stopped for an explicit Start.
   Status refreshes from Settings, app activation, helper health, or the menu bar
   are read-only and must not retry a failed start. An eligible new USB attach or
   an explicit Start action may arm another attempt; Stop preserves current guest
@@ -192,8 +193,9 @@ macOS 0.0.0.0/1 and 128.0.0.0/1 routes
   retention policy.
 - `ConsoleSessionStore` owns serial-console text and structured marker
   scanning. `USBSessionStore` owns the atomic USB UI snapshot, prompt queue,
-  de-duplication, and VM-asset deferral. `VMConfigurationStore` owns persisted
-  VM settings and the optional scratch disk.
+  de-duplication, and VM-asset deferral. `AppPreferencesStore` owns the persisted
+  set of Auto Connect reconnect identities with other application preferences.
+  `VMConfigurationStore` owns persisted VM settings and the optional scratch disk.
 - Normal operation requires completed onboarding, valid VM Assets, and the
   current enabled network helper before AccessoryAccess monitoring starts or
   reloads. Debug mode may expose controls, but it does not bypass USB
@@ -207,8 +209,14 @@ macOS 0.0.0.0/1 and 128.0.0.0/1 routes
 
 - USB passthrough must use an AccessoryAccess `AAUSBAccessory` with
   `VZUSBPassthroughDeviceConfiguration(device:)`.
-- A newly available USB device is never attached silently. The app asks first,
-  starts the VM when needed, then attaches the approved device.
+- A newly available USB device normally requires approval before the app starts
+  the VM and attaches it. The sole silent exception is a device whose unique,
+  persisted `USBAccessoryReconnectIdentity` is enabled for Auto Connect. When
+  multiple enabled devices are detected together, the first availability event
+  wins one deferred-turn evaluation through the same serialized attachment
+  workflow. Auto Connect proceeds only when no accessory owns the current VM
+  session; an unavailable or ambiguous identity fails closed without a later
+  automatic retry.
 - One VM boot corresponds to one passthrough attachment lifetime. Manual
   detach, physical disconnect, or passthrough disconnect stops that VM session.
 - Preserve VM-generation and USB-operation tokens so callbacks from old

--- a/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
@@ -10,6 +10,13 @@ private struct PendingUSBAttachment: Equatable {
     let allowsAutomaticNetworkRoutingStart: Bool
     var startedVM: Bool
 }
+
+private struct PendingUSBAutoConnectRequest: Equatable {
+    let accessoryID: UInt64
+    let reconnectIdentity: USBAccessoryReconnectIdentity
+    let token: UUID
+}
+
 private enum USBAttachmentWorkflowState: Equatable {
     case idle
     case waitingForVM(PendingUSBAttachment)
@@ -66,6 +73,8 @@ private enum VMRestartWorkflowRequest {
 final class TetheringWorkflowCoordinator {
     struct Actions {
         let canPresentUSBAttachmentPrompt: () -> Bool
+        let canBeginAutoConnect: () -> Bool
+        let isAutoConnectEnabled: (USBAccessoryReconnectIdentity) -> Bool
         let canContinueVMRestart: () -> Bool
         let stopNetworkRouting: (String) async -> Bool
         let startVirtualMachine: () -> Bool
@@ -83,6 +92,7 @@ final class TetheringWorkflowCoordinator {
     private var runtimeState: VMRuntimeState
     private var attachmentState: USBAttachmentWorkflowState = .idle
     private var vmRestartState: VMRestartWorkflowState = .idle
+    private var pendingAutoConnectRequest: PendingUSBAutoConnectRequest?
 
     init(
         assetProvider: VMAssetProviding,
@@ -366,6 +376,31 @@ final class TetheringWorkflowCoordinator {
         presentNextUSBAttachmentPromptIfPossible()
     }
 
+    func autoConnectAccessoryDidBecomeAvailable(_ record: USBAccessoryRecord) {
+        guard let reconnectIdentity = record.reconnectIdentity,
+              actions.isAutoConnectEnabled(reconnectIdentity),
+              pendingAutoConnectRequest == nil else {
+            return
+        }
+
+        let request = PendingUSBAutoConnectRequest(
+            accessoryID: record.id,
+            reconnectIdentity: reconnectIdentity,
+            token: UUID()
+        )
+        pendingAutoConnectRequest = request
+
+        Task { @MainActor [weak self] in
+            await Task.yield()
+            guard let self,
+                  self.pendingAutoConnectRequest == request else {
+                return
+            }
+            self.pendingAutoConnectRequest = nil
+            self.attemptAutoConnect(request)
+        }
+    }
+
     func accessoryDidBecomeUnavailable(_ accessoryID: UInt64) {
         usbSession.removeDeferredAttachment(accessoryID: accessoryID)
         guard pendingAttachmentAccessoryID == accessoryID else { return }
@@ -419,6 +454,7 @@ final class TetheringWorkflowCoordinator {
     }
 
     func cancelPendingWorkForReset() {
+        pendingAutoConnectRequest = nil
         cancelPendingAttachment(
             reason: "app settings reset",
             presentNextPrompt: false
@@ -437,6 +473,57 @@ final class TetheringWorkflowCoordinator {
 
     private var pendingAttachmentStartedVM: Bool {
         attachmentState.attachment?.startedVM == true
+    }
+
+    private func attemptAutoConnect(_ request: PendingUSBAutoConnectRequest) {
+        guard actions.isAutoConnectEnabled(request.reconnectIdentity),
+              usbSession.isAccessoryMonitoring,
+              let accessory = usbSession.uniqueAccessory(
+                matching: request.reconnectIdentity
+              ),
+              accessory.id == request.accessoryID else {
+            appendEventLog(
+                "USB Auto Connect ignored because its remembered identity " +
+                    "is unavailable or ambiguous.",
+                level: .debug,
+                category: .usb
+            )
+            return
+        }
+
+        usbSession.discardAttachmentWork(accessoryID: request.accessoryID)
+
+        guard usbSession.attachedAccessoryID == nil,
+              usbSession.vmSessionAccessoryID == nil,
+              attachmentState == .idle,
+              vmRestartState == .idle,
+              assetProvider.hasConfiguredAssets,
+              !assetProvider.isBusy,
+              !attachmentRequiresVMStopRetry,
+              actions.canBeginAutoConnect(),
+              usbCoordinator.canRequestAttachment(for: request.accessoryID) else {
+            appendEventLog(
+                "USB Auto Connect ignored for registry " +
+                    "\(accessory.registryIDText) because attachment is not " +
+                    "currently available.",
+                level: .debug,
+                category: .usb
+            )
+            return
+        }
+
+        usbSession.deferPresentedAttachmentPrompt()
+        guard beginAttachmentWorkflow(
+            accessoryID: request.accessoryID,
+            allowsAutomaticNetworkRoutingStart: false
+        ) != nil else {
+            return
+        }
+        appendEventLog(
+            "USB Auto Connect started for registry \(accessory.registryIDText).",
+            level: .info,
+            category: .usb
+        )
     }
 
     @discardableResult

--- a/ThruRNDIS/Models/USBAccessoryRecord.swift
+++ b/ThruRNDIS/Models/USBAccessoryRecord.swift
@@ -26,8 +26,8 @@ struct USBInterfaceSummary: Hashable, Sendable {
     }
 }
 
-struct USBAccessoryReconnectIdentity: Hashable, Sendable {
-    enum Anchor: Hashable, Sendable {
+struct USBAccessoryReconnectIdentity: Codable, Hashable, Sendable {
+    enum Anchor: Codable, Hashable, Sendable {
         case containerID(UUID)
         case serialNumber(Data, locationID: UInt32)
     }

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -253,6 +253,26 @@
         }
       }
     },
+    "Auto Connect" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 연결"
+          }
+        }
+      }
+    },
+    "Auto Connect for %@" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 자동 연결"
+          }
+        }
+      }
+    },
     "Available devices" : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -845,6 +845,26 @@
         }
       }
     },
+    "Disable" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비활성화"
+          }
+        }
+      }
+    },
+    "Enable" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성화"
+          }
+        }
+      }
+    },
     "Enable Debug Mode" : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -263,16 +263,6 @@
         }
       }
     },
-    "Auto Connect for %@" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 자동 연결"
-          }
-        }
-      }
-    },
     "Available devices" : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -855,6 +855,16 @@
         }
       }
     },
+    "Disabled" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비활성화됨"
+          }
+        }
+      }
+    },
     "Enable" : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -443,16 +443,6 @@
         }
       }
     },
-    "Class" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "클래스"
-          }
-        }
-      }
-    },
     "Clear" : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Stores/AppPreferencesStore.swift
+++ b/ThruRNDIS/Stores/AppPreferencesStore.swift
@@ -34,6 +34,8 @@ final class AppPreferencesStore: ObservableObject {
     }
 
     @Published private(set) var hasCompletedOnboarding: Bool
+    @Published private(set) var usbAutoConnectIdentities:
+        Set<USBAccessoryReconnectIdentity>
     @Published private(set) var launchAtLoginSnapshot: LaunchAtLoginSnapshot
     @Published private(set) var launchAtLoginStatusMessage = ""
 
@@ -58,6 +60,9 @@ final class AppPreferencesStore: ObservableObject {
         self.hasCompletedOnboarding = defaults.integer(
             forKey: DefaultsKey.onboardingVersion
         ) >= Self.currentOnboardingVersion
+        self.usbAutoConnectIdentities = Self.restoredUSBAutoConnectIdentities(
+            defaults: defaults
+        )
         self.launchAtLoginSnapshot = launchAtLoginService.snapshot()
     }
 
@@ -87,14 +92,47 @@ final class AppPreferencesStore: ObservableObject {
         launchAtLoginStatusMessage = ""
     }
 
+    func isUSBAutoConnectEnabled(
+        for identity: USBAccessoryReconnectIdentity
+    ) -> Bool {
+        usbAutoConnectIdentities.contains(identity)
+    }
+
+    @discardableResult
+    func setUSBAutoConnectEnabled(
+        _ isEnabled: Bool,
+        for identity: USBAccessoryReconnectIdentity
+    ) -> Bool {
+        var identities = usbAutoConnectIdentities
+        if isEnabled {
+            identities.insert(identity)
+        } else {
+            identities.remove(identity)
+        }
+
+        guard !identities.isEmpty else {
+            defaults.removeObject(forKey: DefaultsKey.usbAutoConnectIdentities)
+            usbAutoConnectIdentities = []
+            return true
+        }
+        guard let data = try? JSONEncoder().encode(identities) else {
+            return false
+        }
+        defaults.set(data, forKey: DefaultsKey.usbAutoConnectIdentities)
+        usbAutoConnectIdentities = identities
+        return true
+    }
+
     func resetPersistedValues() throws {
         defaults.removeObject(forKey: DefaultsKey.onboardingVersion)
         defaults.removeObject(forKey: DefaultsKey.isDebugModeEnabled)
         defaults.removeObject(forKey: DefaultsKey.shouldAskToAttachDetectedUSBDevices)
+        defaults.removeObject(forKey: DefaultsKey.usbAutoConnectIdentities)
 
         isResettingPersistedValues = true
         isDebugModeEnabled = false
         shouldAskToAttachDetectedUSBDevices = true
+        usbAutoConnectIdentities = []
         hasCompletedOnboarding = false
         isResettingPersistedValues = false
 
@@ -114,5 +152,24 @@ final class AppPreferencesStore: ObservableObject {
         static let onboardingVersion = "Onboarding.completedVersion"
         static let isDebugModeEnabled = "Application.debugModeEnabled"
         static let shouldAskToAttachDetectedUSBDevices = "USB.askToAttachDetectedDevices"
+        static let usbAutoConnectIdentities = "USB.autoConnectIdentities.v1"
+    }
+
+    private static func restoredUSBAutoConnectIdentities(
+        defaults: UserDefaults
+    ) -> Set<USBAccessoryReconnectIdentity> {
+        guard let data = defaults.data(
+            forKey: DefaultsKey.usbAutoConnectIdentities
+        ) else {
+            return []
+        }
+        guard let identities = try? JSONDecoder().decode(
+            Set<USBAccessoryReconnectIdentity>.self,
+            from: data
+        ) else {
+            defaults.removeObject(forKey: DefaultsKey.usbAutoConnectIdentities)
+            return []
+        }
+        return identities
     }
 }

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -86,6 +86,19 @@ final class TetheringStore: ObservableObject {
                     && !self.isResettingAppSettings
                     && !self.isOnboardingPresented
             },
+            canBeginAutoConnect: { [weak self] in
+                guard let self else { return false }
+                return self.acceptsNewWork
+                    && !self.isOnboardingPresented
+                    && !self.isVMStopPreparationInProgress
+                    && self.runtimeEntitlements.accessoryAccessUSB
+                    && self.isNetworkRouteHelperReady
+            },
+            isAutoConnectEnabled: { [weak self] reconnectIdentity in
+                self?.appPreferences.isUSBAutoConnectEnabled(
+                    for: reconnectIdentity
+                ) == true
+            },
             canContinueVMRestart: { [weak self] in
                 self?.acceptsNewWork == true
             },
@@ -321,6 +334,65 @@ final class TetheringStore: ObservableObject {
             && !workflowCoordinator.attachmentRequiresVMStopRetry
             && !assetProvider.isBusy
             && usbCoordinator.canRequestAttachment(for: accessoryID)
+    }
+
+    func isAutoConnectEnabled(for accessory: USBAccessoryRecord) -> Bool {
+        guard let reconnectIdentity = accessory.reconnectIdentity else {
+            return false
+        }
+        return appPreferences.isUSBAutoConnectEnabled(
+            for: reconnectIdentity
+        )
+    }
+
+    func canEnableAutoConnect(for accessory: USBAccessoryRecord) -> Bool {
+        guard let reconnectIdentity = accessory.reconnectIdentity else {
+            return false
+        }
+        return usbSession.uniqueAccessory(
+            matching: reconnectIdentity
+        )?.id == accessory.id
+    }
+
+    func setAutoConnectEnabled(
+        _ isEnabled: Bool,
+        for accessory: USBAccessoryRecord
+    ) {
+        guard acceptsNewWork,
+              let currentAccessory = accessories.first(where: {
+                $0.id == accessory.id
+              }) else {
+            return
+        }
+
+        if isEnabled, !canEnableAutoConnect(for: currentAccessory) {
+            appendEventLog(
+                "USB Auto Connect was not enabled for registry " +
+                    "\(currentAccessory.registryIDText): a unique reconnect " +
+                    "identity is unavailable.",
+                level: .warning,
+                category: .usb
+            )
+            return
+        }
+
+        if !isEnabled, !isAutoConnectEnabled(for: currentAccessory) {
+            return
+        }
+        guard let reconnectIdentity = currentAccessory.reconnectIdentity,
+              appPreferences.setUSBAutoConnectEnabled(
+                isEnabled,
+                for: reconnectIdentity
+              ) else {
+            return
+        }
+        appendEventLog(
+            isEnabled
+                ? "USB Auto Connect enabled for \(currentAccessory.deviceName)."
+                : "USB Auto Connect disabled for \(currentAccessory.deviceName).",
+            level: .info,
+            category: .usb
+        )
     }
 
     var shouldConfirmApplicationTermination: Bool {
@@ -857,7 +929,7 @@ final class TetheringStore: ObservableObject {
                     )
                     if !allowsAutomaticNetworkRoutingStart {
                         self.appendEventLog(
-                            "Automatic Network Routing start skipped for an explicit USB attachment in debug mode.",
+                            "Automatic Network Routing start was not armed by this USB attachment in debug mode.",
                             level: .debug,
                             category: .network
                         )
@@ -883,6 +955,11 @@ final class TetheringStore: ObservableObject {
         }
         usbCoordinator.onAccessoryAvailable = { [weak self] record in
             guard let self else { return }
+            if self.isAutoConnectEnabled(for: record) {
+                self.workflowCoordinator
+                    .autoConnectAccessoryDidBecomeAvailable(record)
+                return
+            }
             guard self.appPreferences.shouldAskToAttachDetectedUSBDevices else {
                 return
             }

--- a/ThruRNDIS/Stores/USBSessionStore.swift
+++ b/ThruRNDIS/Stores/USBSessionStore.swift
@@ -42,6 +42,15 @@ final class USBSessionStore: ObservableObject {
         snapshot.vmSessionAccessoryID
     }
 
+    func uniqueAccessory(
+        matching reconnectIdentity: USBAccessoryReconnectIdentity
+    ) -> USBAccessoryRecord? {
+        let matches = accessories.filter {
+            $0.reconnectIdentity == reconnectIdentity
+        }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
     func apply(_ snapshot: USBSessionSnapshot) {
         guard snapshot != self.snapshot else {
             return
@@ -66,6 +75,13 @@ final class USBSessionStore: ObservableObject {
 
     func clearAttachmentPrompt() {
         attachmentPrompt = nil
+    }
+
+    func deferPresentedAttachmentPrompt() {
+        guard let prompt = takeAttachmentPrompt() else {
+            return
+        }
+        enqueueAttachmentPrompt(prompt)
     }
 
     func enqueueAttachmentPrompt(_ prompt: USBAttachmentPrompt) {

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -90,9 +90,9 @@ struct USBDevicesView: View {
                             .disabled(!store.isAutoConnectEnabled(for: accessory))
                         } label: {
                             if store.isAutoConnectEnabled(for: accessory) {
-                                Text("Enable")
+                                Text("Enabled")
                             } else {
-                                Text("Disable")
+                                Text("Disabled")
                             }
                         }
                         .menuStyle(.borderlessButton)
@@ -104,6 +104,13 @@ struct USBDevicesView: View {
                         )
                         .accessibilityLabel(
                             Text("Auto Connect for \(accessory.deviceName)")
+                        )
+                        .accessibilityValue(
+                            Text(
+                                store.isAutoConnectEnabled(for: accessory)
+                                    ? "Enabled"
+                                    : "Disabled"
+                            )
                         )
                     }
                     .width(80)

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -78,18 +78,32 @@ struct USBDevicesView: View {
                     selection: selectedAccessoryBinding
                 ) {
                     TableColumn("Auto Connect") { accessory in
-                        Toggle(
-                            isOn: autoConnectBinding(for: accessory)
-                        ) {
-                            Text("Auto Connect for \(accessory.deviceName)")
+                        Menu {
+                            Button("Enable") {
+                                store.setAutoConnectEnabled(true, for: accessory)
+                            }
+                            .disabled(store.isAutoConnectEnabled(for: accessory))
+
+                            Button("Disable") {
+                                store.setAutoConnectEnabled(false, for: accessory)
+                            }
+                            .disabled(!store.isAutoConnectEnabled(for: accessory))
+                        } label: {
+                            if store.isAutoConnectEnabled(for: accessory) {
+                                Text("Enable")
+                            } else {
+                                Text("Disable")
+                            }
                         }
-                        .labelsHidden()
-                        .toggleStyle(.checkbox)
-                        .buttonStyle(.borderless)
+                        .menuStyle(.borderlessButton)
+                        .controlSize(.regular)
                         .frame(maxWidth: .infinity, alignment: .center)
                         .disabled(
                             !store.canEnableAutoConnect(for: accessory)
                                 && !store.isAutoConnectEnabled(for: accessory)
+                        )
+                        .accessibilityLabel(
+                            Text("Auto Connect for \(accessory.deviceName)")
                         )
                     }
                     .width(80)
@@ -179,17 +193,6 @@ struct USBDevicesView: View {
         Binding(
             get: { usbSession.selectedAccessoryID },
             set: { store.selectAccessory(id: $0) }
-        )
-    }
-
-    private func autoConnectBinding(
-        for accessory: USBAccessoryRecord
-    ) -> Binding<Bool> {
-        Binding(
-            get: { store.isAutoConnectEnabled(for: accessory) },
-            set: {
-                store.setAutoConnectEnabled($0, for: accessory)
-            }
         )
     }
 

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -92,7 +92,7 @@ struct USBDevicesView: View {
                                 && !store.isAutoConnectEnabled(for: accessory)
                         )
                     }
-                    .width(100)
+                    .width(80)
 
                     TableColumn("Device") { accessory in
                         HStack(spacing: 6) {
@@ -117,11 +117,6 @@ struct USBDevicesView: View {
                             .lineLimit(1)
                     }
                     .width(90)
-
-                    TableColumn("Class") { accessory in
-                        Text(verbatim: accessory.classText)
-                    }
-                    .width(70)
 
                     TableColumn("Registry") { accessory in
                         Text(verbatim: accessory.registryIDText)

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -77,17 +77,39 @@ struct USBDevicesView: View {
                     displayedAccessories,
                     selection: selectedAccessoryBinding
                 ) {
-                    TableColumn("") { accessory in
-                        if accessory.id == usbSession.attachedAccessoryID {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
-                                .frame(maxWidth: .infinity, alignment: .center)
-                                .accessibilityLabel(Text("Attached"))
-                        } else {
-                            EmptyView()
+                    TableColumn("Auto Connect") { accessory in
+                        Toggle(
+                            isOn: autoConnectBinding(for: accessory)
+                        ) {
+                            Text("Auto Connect for \(accessory.deviceName)")
                         }
+                        .labelsHidden()
+                        .toggleStyle(.checkbox)
+                        .buttonStyle(.borderless)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .disabled(
+                            !store.canEnableAutoConnect(for: accessory)
+                                && !store.isAutoConnectEnabled(for: accessory)
+                        )
                     }
-                    .width(20)
+                    .width(100)
+
+                    TableColumn("Device") { accessory in
+                        HStack(spacing: 6) {
+                            Group {
+                                if accessory.id == usbSession.attachedAccessoryID {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                        .accessibilityLabel(Text("Attached"))
+                                }
+                            }
+                            .frame(width: 16)
+
+                            Text(verbatim: accessory.deviceName)
+                        }
+                        .lineLimit(1)
+                        .accessibilityElement(children: .combine)
+                    }
 
                     TableColumn("VID:PID") { accessory in
                         Text(verbatim: accessory.usbIDText)
@@ -95,11 +117,6 @@ struct USBDevicesView: View {
                             .lineLimit(1)
                     }
                     .width(90)
-
-                    TableColumn("Device") { accessory in
-                        Text(verbatim: accessory.deviceName)
-                            .lineLimit(1)
-                    }
 
                     TableColumn("Class") { accessory in
                         Text(verbatim: accessory.classText)
@@ -167,6 +184,17 @@ struct USBDevicesView: View {
         Binding(
             get: { usbSession.selectedAccessoryID },
             set: { store.selectAccessory(id: $0) }
+        )
+    }
+
+    private func autoConnectBinding(
+        for accessory: USBAccessoryRecord
+    ) -> Binding<Bool> {
+        Binding(
+            get: { store.isAutoConnectEnabled(for: accessory) },
+            set: {
+                store.setAutoConnectEnabled($0, for: accessory)
+            }
         )
     }
 

--- a/ThruRNDIS/Views/Settings/USBDevicesView.swift
+++ b/ThruRNDIS/Views/Settings/USBDevicesView.swift
@@ -102,9 +102,6 @@ struct USBDevicesView: View {
                             !store.canEnableAutoConnect(for: accessory)
                                 && !store.isAutoConnectEnabled(for: accessory)
                         )
-                        .accessibilityLabel(
-                            Text("Auto Connect for \(accessory.deviceName)")
-                        )
                         .accessibilityValue(
                             Text(
                                 store.isAutoConnectEnabled(for: accessory)
@@ -113,7 +110,7 @@ struct USBDevicesView: View {
                             )
                         )
                     }
-                    .width(80)
+                    .width(85)
 
                     TableColumn("Device") { accessory in
                         HStack(spacing: 6) {


### PR DESCRIPTION
## Summary

- remember selected USB accessory reconnect identities and automatically attach the first matching available device through the existing serialized workflow
- fail closed for unavailable or ambiguous identities while preserving explicit Network Routing start behavior in debug mode
- add localized Auto Connect controls and refine the USB device table status presentation

## Validation

- unsigned Debug build succeeded with CODE_SIGNING_ALLOWED=NO
- project has no automated test target
- signed entitlement and physical RNDIS device behavior were not exercised