### PR TITLE
feat(menu-bar): show integrated status dot

### DIFF
--- a/ThruRNDIS/Presentation/MenuBarController.swift
+++ b/ThruRNDIS/Presentation/MenuBarController.swift
@@ -51,7 +51,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         self.assetWorkflowCoordinator = assetWorkflowCoordinator
         self.openSettings = openSettings
         statusItem = NSStatusBar.system.statusItem(
-            withLength: NSStatusItem.squareLength
+            withLength: NSStatusItem.variableLength
         )
         super.init()
 
@@ -286,13 +286,30 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     private func updateStatusButton() {
         guard let button = statusItem.button else { return }
+        let status = combinedStatus
         button.image = Self.statusBarImage
+        button.imagePosition = .imageLeading
+        button.imageHugsTitle = true
+        button.attributedTitle = Self.statusDotTitle(
+            color: combinedStatusColor(status)
+        )
         button.setAccessibilityLabel(String(localized: "ThruRNDIS status"))
+        button.setAccessibilityValue(status.title)
         if configurationGuidanceTitles.isEmpty {
-            button.toolTip = "ThruRNDIS — \(combinedStatus.title)"
+            button.toolTip = "ThruRNDIS — \(status.title)"
         } else {
             button.toolTip = configurationGuidanceTitles.joined(separator: "\n")
         }
+    }
+
+    private static func statusDotTitle(color: NSColor) -> NSAttributedString {
+        NSAttributedString(
+            string: "●",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 6, weight: .medium),
+                .foregroundColor: color,
+            ]
+        )
     }
 
     private var configurationGuidanceTitles: [String] {

--- a/ThruRNDIS/Presentation/MenuBarController.swift
+++ b/ThruRNDIS/Presentation/MenuBarController.swift
@@ -58,7 +58,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         menu.delegate = self
         menu.autoenablesItems = false
         statusItem.menu = menu
-        updateStatusButton()
         rebuildMenu()
 
         Publishers.MergeMany([
@@ -117,6 +116,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func rebuildMenu() {
+        let status = combinedStatus
         menu.removeAllItems()
         clearMenuReferences()
 
@@ -126,7 +126,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             || store.appPreferences.isDebugModeEnabled
         if displaysOperations {
             if !guidance.isEmpty { menu.addItem(.separator()) }
-            addStatusSection()
+            addStatusSection(status: status)
             if store.appPreferences.isDebugModeEnabled {
                 menu.addItem(.separator())
                 addVMControlsSection()
@@ -139,10 +139,10 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             }
         }
         addSettingsAndQuitItems()
-        refreshPresentation()
+        refreshPresentation(with: status)
     }
 
-    private func addStatusSection() {
+    private func addStatusSection(status: MenuBarCombinedStatus) {
         if store.appPreferences.isDebugModeEnabled {
             vmStatusItem = statusItemLine(
                 title: vmStatusTitle,
@@ -160,7 +160,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             menu.addItem(usbStatusItem!)
             menu.addItem(networkStatusItem!)
         } else {
-            let status = combinedStatus
             combinedStatusItem = statusItemLine(
                 title: status.title,
                 dotColor: combinedStatusColor(status)
@@ -237,8 +236,11 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func refreshPresentation() {
-        updateStatusButton()
-        let status = combinedStatus
+        refreshPresentation(with: combinedStatus)
+    }
+
+    private func refreshPresentation(with status: MenuBarCombinedStatus) {
+        updateStatusButton(status: status)
         updateStatusItem(
             combinedStatusItem,
             title: status.title,
@@ -284,9 +286,8 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         stopNetworkItem?.isEnabled = networkRoute.canStop
     }
 
-    private func updateStatusButton() {
+    private func updateStatusButton(status: MenuBarCombinedStatus) {
         guard let button = statusItem.button else { return }
-        let status = combinedStatus
         button.image = Self.statusBarImage
         button.imagePosition = .imageLeading
         button.imageHugsTitle = true


### PR DESCRIPTION
## Summary

Adds a compact, runtime-colored integrated status dot beside the existing template menu bar icon so the overall tethering state is visible without opening the menu.

## Changes

- Shows the integrated status dot in both normal and debug modes without adding image assets.
- Uses the existing inactive, partially active, and active color mapping.
- Keeps the tooltip and accessibility value synchronized with the same combined status.
- Computes one `MenuBarCombinedStatus` snapshot per presentation update and reuses it for the menu bar button and menu row.

## Related issue

None.

## Validation

- [ ] `./script/build_and_run.sh --verify`
- [x] Checks run and unverified runtime paths are documented
- [ ] Signed Runtime validation with `./script/build_and_install.sh`
- [ ] Real USB/VZNAT route validation
- [x] Not applicable; explanation: this is a presentation-only change. App launch, signed helper behavior, and real USB/VZNAT routing were not exercised.

Checks run:

- `plutil -lint` for the project, plist, and entitlement files
- `xmllint --noout` for the shared Xcode schemes
- `xcodebuild -list -project ThruRNDIS.xcodeproj`
- unsigned Debug `xcodebuild` with `CODE_SIGNING_ALLOWED=NO` — succeeded

`plutil` does not recognize Xcode `.xcscheme` XML as a property-list schema and reports the root `Scheme` tag as unknown. Both schemes passed XML validation and were recognized by `xcodebuild -list`.

## User-facing impact

The menu bar icon now displays a 6-point colored dot on its right. Red indicates inactive, orange indicates partially active, and green indicates active. The indicator appears in both normal and debug modes.

No screenshot was captured because the app was not launched, avoiding interruption of any active tethering session.

## Security and architecture

None. The change is confined to AppKit presentation code and does not modify USB handling, VM lifecycle, VZNAT host routes, the privileged helper, VM assets, signing, security, or privacy behavior.

## Checklist

- [x] The pull request has one focused purpose.
- [x] The title follows Conventional Commits, for example `fix(usb): serialize detach handling`.
- [x] Behavior changes include appropriate build or runtime validation, with unavailable paths explained.
- [x] User-facing behavior and operational changes are documented.
- [x] New, moved, renamed, or deleted Swift files are reflected in Xcode groups, target membership, and build phases.
- [x] No credentials, provisioning profiles, personal signing values, or local build artifacts are included.
- [x] Guest VM scripts and VM Asset build tooling remain in `Afcoo/ThruRNDIS_VM_Assets`.
