### PR TITLE
fix(menu-bar): unify status colors and error presentation

### DIFF
--- a/ThruRNDIS/Coordinators/USBAccessoryCoordinator.swift
+++ b/ThruRNDIS/Coordinators/USBAccessoryCoordinator.swift
@@ -67,6 +67,7 @@ final class USBAccessoryCoordinator {
 
     private(set) var accessories: [USBAccessoryRecord] = []
     private(set) var isAccessoryMonitoring = false
+    private(set) var accessoryMonitoringErrorMessage: String?
     private(set) var selectedAccessoryID: UInt64?
     private(set) var attachedAccessoryID: UInt64?
     private(set) var vmSessionAccessoryID: UInt64?
@@ -138,6 +139,7 @@ final class USBAccessoryCoordinator {
 
         isRegistrationPending = true
         isAccessoryMonitoring = true
+        accessoryMonitoringErrorMessage = nil
         monitorGeneration &+= 1
         configureAccessoryMonitor(generation: monitorGeneration)
         notifyStateChanged()
@@ -184,6 +186,9 @@ final class USBAccessoryCoordinator {
                     self.notifyStateChanged()
                     completion?()
                 case .failure(let error):
+                    if self.isAccessoryMonitoring {
+                        self.accessoryMonitoringErrorMessage = error.localizedDescription
+                    }
                     self.isAccessoryMonitoring = false
                     self.onStatusMessage?(error.localizedDescription)
                     self.reportEventLog(
@@ -211,6 +216,10 @@ final class USBAccessoryCoordinator {
         cancelsReload: Bool,
         completion: (() -> Void)?
     ) {
+        if accessoryMonitoringErrorMessage != nil {
+            accessoryMonitoringErrorMessage = nil
+            notifyStateChanged()
+        }
         if cancelsReload, isReloadInProgress {
             isReloadInProgress = false
             reportEventLog(

--- a/ThruRNDIS/Models/MenuBarCombinedStatus.swift
+++ b/ThruRNDIS/Models/MenuBarCombinedStatus.swift
@@ -9,6 +9,7 @@ struct MenuBarCombinedStatus: Equatable {
         case inactive
         case partiallyActive
         case active
+        case needsAttention
     }
 
     enum Stage: Equatable {
@@ -31,18 +32,23 @@ struct MenuBarCombinedStatus: Equatable {
         vznatGatewayIPv4Address: String?,
         isRNDISRouteReady: Bool,
         isNetworkRouteTransitioning: Bool,
-        networkRouteSnapshot: NetworkRouteSnapshot?
+        networkRouteSnapshot: NetworkRouteSnapshot?,
+        hasBlockingError: Bool
     ) {
         let isVMRunning = vmRuntimeState == .running
         let isVMNetworkActive = networkRouteSnapshot?.state == .active
         let components = [isVMRunning, isUSBAttached, isVMNetworkActive]
-        switch components.filter({ $0 }).count {
-        case 0:
-            activity = .inactive
-        case components.count:
-            activity = .active
-        default:
-            activity = .partiallyActive
+        if hasBlockingError {
+            activity = .needsAttention
+        } else {
+            switch components.filter({ $0 }).count {
+            case 0:
+                activity = .inactive
+            case components.count:
+                activity = .active
+            default:
+                activity = .partiallyActive
+            }
         }
 
         if !isVMRunning {

--- a/ThruRNDIS/Models/MenuBarCombinedStatus.swift
+++ b/ThruRNDIS/Models/MenuBarCombinedStatus.swift
@@ -13,6 +13,9 @@ struct MenuBarCombinedStatus: Equatable {
     }
 
     enum Stage: Equatable {
+        case vmAssetsNotConfigured
+        case networkHelperNotConfigured
+        case vmAssetsAndNetworkHelperNotConfigured
         case inactive
         case usbNotAttached
         case waitingForGuestNetwork
@@ -24,8 +27,11 @@ struct MenuBarCombinedStatus: Equatable {
 
     let activity: Activity
     let stage: Stage
+    let requiresConfiguration: Bool
 
     init(
+        hasConfiguredVMAssets: Bool,
+        isNetworkHelperEnabled: Bool,
         vmRuntimeState: VMRuntimeState,
         isUSBAttached: Bool,
         guestIPv4Address: String?,
@@ -38,7 +44,8 @@ struct MenuBarCombinedStatus: Equatable {
         let isVMRunning = vmRuntimeState == .running
         let isVMNetworkActive = networkRouteSnapshot?.state == .active
         let components = [isVMRunning, isUSBAttached, isVMNetworkActive]
-        if hasBlockingError {
+        requiresConfiguration = !hasConfiguredVMAssets || !isNetworkHelperEnabled
+        if requiresConfiguration || hasBlockingError {
             activity = .needsAttention
         } else {
             switch components.filter({ $0 }).count {
@@ -51,7 +58,13 @@ struct MenuBarCombinedStatus: Equatable {
             }
         }
 
-        if !isVMRunning {
+        if !hasConfiguredVMAssets && !isNetworkHelperEnabled {
+            stage = .vmAssetsAndNetworkHelperNotConfigured
+        } else if !hasConfiguredVMAssets {
+            stage = .vmAssetsNotConfigured
+        } else if !isNetworkHelperEnabled {
+            stage = .networkHelperNotConfigured
+        } else if !isVMRunning {
             stage = .inactive
         } else if !isUSBAttached {
             stage = .usbNotAttached
@@ -71,6 +84,12 @@ struct MenuBarCombinedStatus: Equatable {
 
     var title: String {
         switch stage {
+        case .vmAssetsNotConfigured:
+            String(localized: "VM Assets Setup Required")
+        case .networkHelperNotConfigured:
+            String(localized: "Network Helper Setup Required")
+        case .vmAssetsAndNetworkHelperNotConfigured:
+            String(localized: "VM Assets and Network Helper Setup Required")
         case .inactive:
             String(localized: "menuBar.combinedStatus.notRunning", defaultValue: "Not Running")
         case .usbNotAttached:

--- a/ThruRNDIS/Models/MenuBarCombinedStatus.swift
+++ b/ThruRNDIS/Models/MenuBarCombinedStatus.swift
@@ -16,6 +16,7 @@ struct MenuBarCombinedStatus: Equatable {
         case vmAssetsNotConfigured
         case networkHelperNotConfigured
         case vmAssetsAndNetworkHelperNotConfigured
+        case needsAttention
         case inactive
         case usbNotAttached
         case waitingForGuestNetwork
@@ -64,6 +65,8 @@ struct MenuBarCombinedStatus: Equatable {
             stage = .vmAssetsNotConfigured
         } else if !isNetworkHelperEnabled {
             stage = .networkHelperNotConfigured
+        } else if hasBlockingError {
+            stage = .needsAttention
         } else if !isVMRunning {
             stage = .inactive
         } else if !isUSBAttached {
@@ -90,6 +93,8 @@ struct MenuBarCombinedStatus: Equatable {
             String(localized: "Network Helper Setup Required")
         case .vmAssetsAndNetworkHelperNotConfigured:
             String(localized: "VM Assets and Network Helper Setup Required")
+        case .needsAttention:
+            String(localized: "Needs Attention")
         case .inactive:
             String(localized: "menuBar.combinedStatus.notRunning", defaultValue: "Not Running")
         case .usbNotAttached:

--- a/ThruRNDIS/Models/MenuBarCombinedStatus.swift
+++ b/ThruRNDIS/Models/MenuBarCombinedStatus.swift
@@ -9,14 +9,14 @@ struct MenuBarCombinedStatus: Equatable {
         case inactive
         case partiallyActive
         case active
-        case needsAttention
+        case error
     }
 
     enum Stage: Equatable {
         case vmAssetsNotConfigured
         case networkHelperNotConfigured
         case vmAssetsAndNetworkHelperNotConfigured
-        case needsAttention
+        case error
         case inactive
         case usbNotAttached
         case waitingForGuestNetwork
@@ -47,7 +47,7 @@ struct MenuBarCombinedStatus: Equatable {
         let components = [isVMRunning, isUSBAttached, isVMNetworkActive]
         requiresConfiguration = !hasConfiguredVMAssets || !isNetworkHelperEnabled
         if requiresConfiguration || hasBlockingError {
-            activity = .needsAttention
+            activity = .error
         } else {
             switch components.filter({ $0 }).count {
             case 0:
@@ -66,7 +66,7 @@ struct MenuBarCombinedStatus: Equatable {
         } else if !isNetworkHelperEnabled {
             stage = .networkHelperNotConfigured
         } else if hasBlockingError {
-            stage = .needsAttention
+            stage = .error
         } else if !isVMRunning {
             stage = .inactive
         } else if !isUSBAttached {
@@ -93,8 +93,8 @@ struct MenuBarCombinedStatus: Equatable {
             String(localized: "Network Helper Setup Required")
         case .vmAssetsAndNetworkHelperNotConfigured:
             String(localized: "VM Assets and Network Helper Setup Required")
-        case .needsAttention:
-            String(localized: "Needs Attention")
+        case .error:
+            String(localized: "Error")
         case .inactive:
             String(localized: "menuBar.combinedStatus.notRunning", defaultValue: "Not Running")
         case .usbNotAttached:

--- a/ThruRNDIS/Presentation/MenuBarController.swift
+++ b/ThruRNDIS/Presentation/MenuBarController.swift
@@ -64,6 +64,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             store.objectWillChange.eraseToAnyPublisher(),
             store.appPreferences.objectWillChange.eraseToAnyPublisher(),
             store.usbSession.objectWillChange.eraseToAnyPublisher(),
+            store.portForwarding.objectWillChange.eraseToAnyPublisher(),
             networkRoute.objectWillChange.eraseToAnyPublisher(),
             networkRoute.helper.objectWillChange.eraseToAnyPublisher(),
             assetWorkflowCoordinator.objectWillChange.eraseToAnyPublisher(),
@@ -146,15 +147,15 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         if store.appPreferences.isDebugModeEnabled {
             vmStatusItem = statusItemLine(
                 title: vmStatusTitle,
-                dotColor: vmStatusColor
+                dotColor: statusColor(vmStatusActivity)
             )
             usbStatusItem = statusItemLine(
                 title: usbStatusTitle,
-                dotColor: usbStatusColor
+                dotColor: statusColor(usbStatusActivity)
             )
             networkStatusItem = statusItemLine(
                 title: networkStatusTitle,
-                dotColor: networkStatusColor
+                dotColor: statusColor(networkStatusActivity)
             )
             menu.addItem(vmStatusItem!)
             menu.addItem(usbStatusItem!)
@@ -162,7 +163,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         } else {
             combinedStatusItem = statusItemLine(
                 title: status.title,
-                dotColor: combinedStatusColor(status)
+                dotColor: statusColor(status.activity)
             )
             menu.addItem(combinedStatusItem!)
         }
@@ -244,22 +245,22 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         updateStatusItem(
             combinedStatusItem,
             title: status.title,
-            dotColor: combinedStatusColor(status)
+            dotColor: statusColor(status.activity)
         )
         updateStatusItem(
             vmStatusItem,
             title: vmStatusTitle,
-            dotColor: vmStatusColor
+            dotColor: statusColor(vmStatusActivity)
         )
         updateStatusItem(
             usbStatusItem,
             title: usbStatusTitle,
-            dotColor: usbStatusColor
+            dotColor: statusColor(usbStatusActivity)
         )
         updateStatusItem(
             networkStatusItem,
             title: networkStatusTitle,
-            dotColor: networkStatusColor
+            dotColor: statusColor(networkStatusActivity)
         )
 
         if store.runtimeState == .running {
@@ -292,7 +293,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         button.imagePosition = .imageLeading
         button.imageHugsTitle = true
         button.attributedTitle = Self.statusDotTitle(
-            color: combinedStatusColor(status)
+            color: statusColor(status.activity)
         )
         button.setAccessibilityLabel(String(localized: "ThruRNDIS status"))
         button.setAccessibilityValue(status.title)
@@ -331,7 +332,10 @@ final class MenuBarController: NSObject, NSMenuDelegate {
                 networkRoute.vznatGatewayIPv4Address,
             isRNDISRouteReady: networkRoute.isRNDISRouteReady,
             isNetworkRouteTransitioning: networkRoute.operation != nil,
-            networkRouteSnapshot: networkRoute.snapshot
+            networkRouteSnapshot: networkRoute.snapshot,
+            hasBlockingError: vmStatusActivity == .needsAttention
+                || usbStatusActivity == .needsAttention
+                || networkStatusActivity == .needsAttention
         )
     }
 
@@ -372,48 +376,68 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         return String(localized: "Network Routing: \(title)")
     }
 
-    private var vmStatusColor: NSColor {
-        switch store.vmDisplayState {
+    private var vmStatusActivity: MenuBarCombinedStatus.Activity {
+        // A disabled Start action can also mean a normal lifecycle transition.
+        // Only missing prerequisites and recorded failures require attention.
+        if !store.hasConfiguredVMAssets
+            || !store.runtimeEntitlements.virtualization
+            || !store.portForwarding.isReadyForVMStart
+            || store.runtimeState == .failed {
+            return .needsAttention
+        }
+        if store.isRestartingVirtualMachine { return .partiallyActive }
+        return switch store.runtimeState {
         case .running:
-            .systemGreen
-        case .restarting:
-            .systemYellow
-        case .stopped:
-            .systemRed
+            .active
+        case .starting, .stopping:
+            .partiallyActive
+        case .idle, .stopped:
+            .inactive
+        case .failed:
+            .needsAttention
         }
     }
 
-    private var usbStatusColor: NSColor {
+    private var usbStatusActivity: MenuBarCombinedStatus.Activity {
+        if !store.runtimeEntitlements.accessoryAccessUSB
+            || store.usbSession.accessoryMonitoringErrorMessage != nil {
+            return .needsAttention
+        }
         if store.usbSession.attachedAccessoryID != nil {
-            return .systemGreen
+            return .active
         }
-        return store.usbSession.accessories.isEmpty ? .systemRed : .systemYellow
+        return .inactive
     }
 
-    private var networkStatusColor: NSColor {
-        guard networkRoute.helper.isAvailable else { return .systemRed }
-        if networkRoute.operation != nil { return .systemYellow }
-        if networkRoute.lastErrorMessage != nil { return .systemRed }
+    private var networkStatusActivity: MenuBarCombinedStatus.Activity {
+        if networkRoute.helper.isOperationInProgress {
+            return .partiallyActive
+        }
+        guard networkRoute.helper.isAvailable else { return .needsAttention }
+        if networkRoute.operation == .starting || networkRoute.operation == .stopping {
+            return .partiallyActive
+        }
+        if networkRoute.lastErrorMessage != nil { return .needsAttention }
         switch networkRoute.snapshot?.state {
         case .active:
-            return .systemGreen
+            return .active
         case .degraded:
-            return .systemRed
-        case .inactive:
-            return .systemRed
-        case nil:
-            return .systemGray
+            return .needsAttention
+        case .inactive, nil:
+            return .inactive
         }
     }
 
-    private func combinedStatusColor(_ status: MenuBarCombinedStatus) -> NSColor {
-        switch status.activity {
+    private func statusColor(_ activity: MenuBarCombinedStatus.Activity) -> NSColor {
+        switch activity {
         case .inactive:
-            .systemRed
+            .systemGray
         case .partiallyActive:
             .systemOrange
         case .active:
             .systemGreen
+        case .needsAttention:
+            .systemRed
         }
     }
 

--- a/ThruRNDIS/Presentation/MenuBarController.swift
+++ b/ThruRNDIS/Presentation/MenuBarController.swift
@@ -237,7 +237,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             title: status.title,
             dotColor: statusColor(status.activity)
         )
-        let hidesDebugStatus = status.activity == .needsAttention
+        let hidesDebugStatus = status.activity == .error
         debugStatusSeparatorItem?.isHidden = hidesDebugStatus
         for (item, presentation) in zip(debugStatusItems, debugStatusPresentations) {
             item.isHidden = hidesDebugStatus
@@ -307,9 +307,9 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             isRNDISRouteReady: networkRoute.isRNDISRouteReady,
             isNetworkRouteTransitioning: networkRoute.operation != nil,
             networkRouteSnapshot: networkRoute.snapshot,
-            hasBlockingError: vmStatusActivity == .needsAttention
-                || usbStatusActivity == .needsAttention
-                || networkStatusActivity == .needsAttention
+            hasBlockingError: vmStatusActivity == .error
+                || usbStatusActivity == .error
+                || networkStatusActivity == .error
         )
     }
 
@@ -365,7 +365,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             || !store.runtimeEntitlements.virtualization
             || !store.portForwarding.isReadyForVMStart
             || store.runtimeState == .failed {
-            return .needsAttention
+            return .error
         }
         if store.isRestartingVirtualMachine { return .partiallyActive }
         return switch store.runtimeState {
@@ -376,14 +376,14 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         case .idle, .stopped:
             .inactive
         case .failed:
-            .needsAttention
+            .error
         }
     }
 
     private var usbStatusActivity: MenuBarCombinedStatus.Activity {
         if !store.runtimeEntitlements.accessoryAccessUSB
             || store.usbSession.accessoryMonitoringErrorMessage != nil {
-            return .needsAttention
+            return .error
         }
         if store.usbSession.attachedAccessoryID != nil {
             return .active
@@ -395,16 +395,16 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         if networkRoute.helper.isOperationInProgress {
             return .partiallyActive
         }
-        guard networkRoute.helper.isAvailable else { return .needsAttention }
+        guard networkRoute.helper.isAvailable else { return .error }
         if networkRoute.operation == .starting || networkRoute.operation == .stopping {
             return .partiallyActive
         }
-        if networkRoute.lastErrorMessage != nil { return .needsAttention }
+        if networkRoute.lastErrorMessage != nil { return .error }
         switch networkRoute.snapshot?.state {
         case .active:
             return .active
         case .degraded:
-            return .needsAttention
+            return .error
         case .inactive, nil:
             return .inactive
         }
@@ -418,7 +418,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             .systemOrange
         case .active:
             .systemGreen
-        case .needsAttention:
+        case .error:
             .systemRed
         }
     }

--- a/ThruRNDIS/Presentation/MenuBarController.swift
+++ b/ThruRNDIS/Presentation/MenuBarController.swift
@@ -27,9 +27,8 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     private let menu = NSMenu()
     private var cancellables: Set<AnyCancellable> = []
     private var combinedStatusItem: NSMenuItem?
-    private var vmStatusItem: NSMenuItem?
-    private var usbStatusItem: NSMenuItem?
-    private var networkStatusItem: NSMenuItem?
+    private var debugStatusSeparatorItem: NSMenuItem?
+    private var debugStatusItems: [NSMenuItem] = []
     private var vmActionItem: NSMenuItem?
     private var stopVMItem: NSMenuItem?
     private var attachSubmenu: NSMenu?
@@ -147,22 +146,16 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         )
         menu.addItem(combinedStatusItem!)
         if store.appPreferences.isDebugModeEnabled {
-            menu.addItem(.separator())
-            vmStatusItem = statusItemLine(
-                title: vmStatusTitle,
-                dotColor: statusColor(vmStatusActivity)
-            )
-            usbStatusItem = statusItemLine(
-                title: usbStatusTitle,
-                dotColor: statusColor(usbStatusActivity)
-            )
-            networkStatusItem = statusItemLine(
-                title: networkStatusTitle,
-                dotColor: statusColor(networkStatusActivity)
-            )
-            menu.addItem(vmStatusItem!)
-            menu.addItem(usbStatusItem!)
-            menu.addItem(networkStatusItem!)
+            let separator = NSMenuItem.separator()
+            debugStatusSeparatorItem = separator
+            menu.addItem(separator)
+            debugStatusItems = debugStatusPresentations.map { presentation in
+                statusItemLine(
+                    title: presentation.title,
+                    dotColor: statusColor(presentation.activity)
+                )
+            }
+            debugStatusItems.forEach { menu.addItem($0) }
         }
     }
 
@@ -244,21 +237,16 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             title: status.title,
             dotColor: statusColor(status.activity)
         )
-        updateStatusItem(
-            vmStatusItem,
-            title: vmStatusTitle,
-            dotColor: statusColor(vmStatusActivity)
-        )
-        updateStatusItem(
-            usbStatusItem,
-            title: usbStatusTitle,
-            dotColor: statusColor(usbStatusActivity)
-        )
-        updateStatusItem(
-            networkStatusItem,
-            title: networkStatusTitle,
-            dotColor: statusColor(networkStatusActivity)
-        )
+        let hidesDebugStatus = status.activity == .needsAttention
+        debugStatusSeparatorItem?.isHidden = hidesDebugStatus
+        for (item, presentation) in zip(debugStatusItems, debugStatusPresentations) {
+            item.isHidden = hidesDebugStatus
+            updateStatusItem(
+                item,
+                title: presentation.title,
+                dotColor: statusColor(presentation.activity)
+            )
+        }
 
         if store.runtimeState == .running {
             vmActionItem?.title = String(localized: "Restart VM")
@@ -323,6 +311,14 @@ final class MenuBarController: NSObject, NSMenuDelegate {
                 || usbStatusActivity == .needsAttention
                 || networkStatusActivity == .needsAttention
         )
+    }
+
+    private var debugStatusPresentations: [(title: String, activity: MenuBarCombinedStatus.Activity)] {
+        [
+            (vmStatusTitle, vmStatusActivity),
+            (usbStatusTitle, usbStatusActivity),
+            (networkStatusTitle, networkStatusActivity),
+        ]
     }
 
     private var vmStatusTitle: String {
@@ -495,9 +491,8 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     private func clearMenuReferences() {
         combinedStatusItem = nil
-        vmStatusItem = nil
-        usbStatusItem = nil
-        networkStatusItem = nil
+        debugStatusSeparatorItem = nil
+        debugStatusItems.removeAll()
         vmActionItem = nil
         stopVMItem = nil
         attachSubmenu = nil

--- a/ThruRNDIS/Presentation/MenuBarController.swift
+++ b/ThruRNDIS/Presentation/MenuBarController.swift
@@ -121,13 +121,10 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         menu.removeAllItems()
         clearMenuReferences()
 
-        let guidance = configurationGuidanceTitles
-        guidance.forEach { menu.addItem(informationalItem(title: $0)) }
-        let displaysOperations = guidance.isEmpty
+        addStatusSection(status: status)
+        let displaysOperations = !status.requiresConfiguration
             || store.appPreferences.isDebugModeEnabled
         if displaysOperations {
-            if !guidance.isEmpty { menu.addItem(.separator()) }
-            addStatusSection(status: status)
             if store.appPreferences.isDebugModeEnabled {
                 menu.addItem(.separator())
                 addVMControlsSection()
@@ -144,7 +141,13 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func addStatusSection(status: MenuBarCombinedStatus) {
+        combinedStatusItem = statusItemLine(
+            title: status.title,
+            dotColor: statusColor(status.activity)
+        )
+        menu.addItem(combinedStatusItem!)
         if store.appPreferences.isDebugModeEnabled {
+            menu.addItem(.separator())
             vmStatusItem = statusItemLine(
                 title: vmStatusTitle,
                 dotColor: statusColor(vmStatusActivity)
@@ -160,12 +163,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             menu.addItem(vmStatusItem!)
             menu.addItem(usbStatusItem!)
             menu.addItem(networkStatusItem!)
-        } else {
-            combinedStatusItem = statusItemLine(
-                title: status.title,
-                dotColor: statusColor(status.activity)
-            )
-            menu.addItem(combinedStatusItem!)
         }
     }
 
@@ -297,11 +294,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         )
         button.setAccessibilityLabel(String(localized: "ThruRNDIS status"))
         button.setAccessibilityValue(status.title)
-        if configurationGuidanceTitles.isEmpty {
-            button.toolTip = "ThruRNDIS — \(status.title)"
-        } else {
-            button.toolTip = configurationGuidanceTitles.joined(separator: "\n")
-        }
+        button.toolTip = "ThruRNDIS — \(status.title)"
     }
 
     private static func statusDotTitle(color: NSColor) -> NSAttributedString {
@@ -314,17 +307,10 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         )
     }
 
-    private var configurationGuidanceTitles: [String] {
-        [
-            assetWorkflowCoordinator.hasConfiguredAssets
-                ? nil : String(localized: "Configure VM Assets in Settings"),
-            networkRoute.helper.registrationStatus == .enabled
-                ? nil : String(localized: "Configure Network Routing in Settings"),
-        ].compactMap { $0 }
-    }
-
     private var combinedStatus: MenuBarCombinedStatus {
         MenuBarCombinedStatus(
+            hasConfiguredVMAssets: store.hasConfiguredVMAssets,
+            isNetworkHelperEnabled: networkRoute.helper.isAvailable,
             vmRuntimeState: store.runtimeState,
             isUSBAttached: store.usbSession.attachedAccessoryID != nil,
             guestIPv4Address: networkRoute.guestIPv4Address,
@@ -480,12 +466,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
         item.image = MenuBarStatusDotImageFactory.makeImage(color: dotColor)
         item.preferredImageVisibility = .visible
-        item.isEnabled = false
-        return item
-    }
-
-    private func informationalItem(title: String) -> NSMenuItem {
-        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
         item.isEnabled = false
         return item
     }

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -3085,6 +3085,16 @@
         }
       }
     },
+    "Error" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오류"
+          }
+        }
+      }
+    },
     "Needs Attention" : {
       "localizations" : {
         "ko" : {

--- a/ThruRNDIS/Resources/Localizable.xcstrings
+++ b/ThruRNDIS/Resources/Localizable.xcstrings
@@ -523,22 +523,22 @@
         }
       }
     },
-    "Configure Network Routing in Settings" : {
+    "Network Helper Setup Required" : {
       "localizations" : {
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "설정에서 네트워크 라우팅을 구성하세요"
+            "value" : "네트워크 헬퍼 설정 필요"
           }
         }
       }
     },
-    "Configure VM Assets in Settings" : {
+    "VM Assets Setup Required" : {
       "localizations" : {
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "설정에서 VM에셋을 구성하세요"
+            "value" : "VM 에셋 설정 필요"
           }
         }
       }
@@ -2689,6 +2689,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "VM 에셋 릴리스"
+          }
+        }
+      }
+    },
+    "VM Assets and Network Helper Setup Required" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VM 에셋 및 네트워크 헬퍼 설정 필요"
           }
         }
       }

--- a/ThruRNDIS/Stores/TetheringStore.swift
+++ b/ThruRNDIS/Stores/TetheringStore.swift
@@ -1114,6 +1114,8 @@ final class TetheringStore: ObservableObject {
             USBSessionSnapshot(
                 accessories: usbCoordinator.accessories,
                 isAccessoryMonitoring: usbCoordinator.isAccessoryMonitoring,
+                accessoryMonitoringErrorMessage:
+                    usbCoordinator.accessoryMonitoringErrorMessage,
                 selectedAccessoryID: usbCoordinator.selectedAccessoryID,
                 attachedAccessoryID: usbCoordinator.attachedAccessoryID,
                 vmSessionAccessoryID: usbCoordinator.vmSessionAccessoryID

--- a/ThruRNDIS/Stores/USBSessionStore.swift
+++ b/ThruRNDIS/Stores/USBSessionStore.swift
@@ -8,6 +8,7 @@ import Foundation
 struct USBSessionSnapshot: Equatable {
     var accessories: [USBAccessoryRecord] = []
     var isAccessoryMonitoring = false
+    var accessoryMonitoringErrorMessage: String?
     var selectedAccessoryID: UInt64?
     var attachedAccessoryID: UInt64?
     var vmSessionAccessoryID: UInt64?
@@ -28,6 +29,10 @@ final class USBSessionStore: ObservableObject {
 
     var isAccessoryMonitoring: Bool {
         snapshot.isAccessoryMonitoring
+    }
+
+    var accessoryMonitoringErrorMessage: String? {
+        snapshot.accessoryMonitoringErrorMessage
     }
 
     var selectedAccessoryID: UInt64? {


### PR DESCRIPTION
## Summary

Stopped components previously used red status dots, while setup failures could appear separately from the combined status or leave an ordinary running/stopped label. This change uses gray for inactivity and red for errors, and makes the combined menu status the primary error indicator in both normal and debug modes.

## Changes

- Share one color policy: gray for inactive, orange for partial activity/transitions, green for active, and red for errors.
- Include missing or invalid VM assets, missing runtime entitlements, invalid port settings, VM failures, USB listener failures, and helper/network errors in the combined error state.
- Show asset/helper setup requirements, including simultaneous requirements, directly in the combined status with its dot. Use `Error` / `오류` for other combined errors.
- Always show combined status at the top of the debug menu. Hide the individual VM/USB/network status rows and their separator during errors, and restore them when the error clears.
- Propagate USB listener registration errors through the existing session snapshot and clear them on retry or stop. Observe port-setting changes so the menu updates when validation changes.

## Related issue

None.

## Validation

- [ ] `./script/build_and_run.sh --verify` — not run; performed an unsigned Debug build without launching the app.
- [x] Checks run and unverified runtime paths are documented
- [ ] Signed Runtime validation with `./script/build_and_install.sh` — not run.
- [ ] Real USB/VZNAT route validation — not run.
- [x] Not applicable; explanation: no helper, entitlement, signing, or host networking implementation changes require installation for compile verification. Signed runtime and live menu behavior remain unverified.

Completed checks:

- `xcodebuild -project ThruRNDIS.xcodeproj -scheme ThruRNDIS -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/ThruRNDIS-status-dot-DerivedData CODE_SIGNING_ALLOWED=NO build` — passed.
- `xcodebuild -list -project ThruRNDIS.xcodeproj` — passed.
- `plutil -lint` for the project, plists, and entitlements — passed. Schemes are XML rather than plists and were validated with `xmllint --noout`.
- String catalog JSON validation and `git diff --check` — passed.
- Reviewed the branch diff against merge base `ed1890d3c2633d1439ff5f749cf008517e60c62f`; no actionable findings identified.

## User-facing impact

Normal-mode setup failures now appear as one red combined-status row. Debug mode always includes the combined status and suppresses its individual status rows during errors. The tooltip and accessibility value use the same combined-status text. English and Korean setup/error strings are included.

Screenshots were not captured; live menu layout and hide/restore behavior were not exercised. No separate documentation or release-note files were changed.

## Security and architecture

USB listener error reporting is added to the existing coordinator/session snapshot flow. USB attachment policy, VM lifecycle decisions, privileged-helper operations, host networking, VM asset installation, and signing configuration are unchanged. No new privileges or dependencies are introduced.

## Checklist

- [x] The pull request has one focused purpose.
- [x] The title follows Conventional Commits.
- [x] Behavior changes include appropriate build or runtime validation, with unavailable paths explained.
- [x] User-facing behavior and operational changes are documented.
- [x] New, moved, renamed, or deleted Swift files are reflected in Xcode groups, target membership, and build phases. No source files were added, moved, renamed, or deleted.
- [x] No credentials, provisioning profiles, personal signing values, or local build artifacts are included.
- [x] Guest VM scripts and VM Asset build tooling remain in `Afcoo/ThruRNDIS_VM_Assets`.
