### PR TITLE
fix(usb): start routing for auto connect in debug mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,10 +91,10 @@ macOS managed IPv4 Network Service
   interfaces when readiness is lost, the VM stops, app settings are reset, or
   the app terminates.
 - Outside debug mode, a successful USB passthrough attachment arms one automatic
-  managed-network start. In debug mode, only an attachment accepted through the
-  detected-device prompt arms that start; remembered Auto Connect attachments
-  and attachments requested from the Settings USB list or menu bar leave routing
-  stopped for an explicit Start.
+  managed-network start. In debug mode, attachments accepted through the
+  detected-device prompt and remembered Auto Connect attachments also arm that
+  start. Only attachments requested from the Settings USB list or menu bar leave
+  routing stopped for an explicit Start.
   Status refreshes from Settings, app activation, helper health, or the menu bar
   are read-only and must not retry a failed start. An eligible new USB attach or
   an explicit Start action may arm another attempt; Stop preserves current guest

--- a/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
+++ b/ThruRNDIS/Coordinators/TetheringWorkflowCoordinator.swift
@@ -515,7 +515,7 @@ final class TetheringWorkflowCoordinator {
         usbSession.deferPresentedAttachmentPrompt()
         guard beginAttachmentWorkflow(
             accessoryID: request.accessoryID,
-            allowsAutomaticNetworkRoutingStart: false
+            allowsAutomaticNetworkRoutingStart: true
         ) != nil else {
             return
         }


### PR DESCRIPTION
## Summary

In debug mode, remembered USB Auto Connect started the VM and attached the device but left Network Routing stopped. Auto Connect now arms one automatic routing start once the helper and guest network are ready.

## Changes

- Allow automatic Network Routing start in the Auto Connect attachment workflow.
- Preserve manual Start for attachments requested directly from Settings or the menu bar in debug mode; detected-device prompt approvals continue to start routing automatically.
- Update `AGENTS.md` to document the behavior.

## Related issue

None.

## Validation

- [ ] `./script/build_and_run.sh --verify`
- [x] Checks run and unverified runtime paths are documented
- [ ] Signed Runtime validation with `./script/build_and_install.sh`
- [ ] Real USB/VZNAT route validation
- [ ] Not applicable; explanation:

Passed the unsigned Debug build with `xcodebuild` on this branch, `git diff --check`, project/plist/entitlement validation, and `xcodebuild -list`. Schemes passed XML validation with `xmllint` because `.xcscheme` files are XML rather than property lists. Validation was limited to build and static checks; app launch, signed installation, and real USB/VZNAT routing remain unverified.

## User-facing impact

Debug-mode Auto Connect proceeds to Network Routing automatically when its prerequisites are satisfied. Direct connection actions in Settings and the menu bar still require manual Start. No UI layout changes.

## Security and architecture

Only the Auto Connect workflow's existing routing-start flag changes. Helper authentication, guest-readiness checks, network mutation ownership, cleanup, and failure retry behavior are unchanged.

## Checklist

- [x] The pull request has one focused purpose.
- [x] The title follows Conventional Commits, for example `fix(usb): serialize detach handling`.
- [x] Behavior changes include appropriate build or runtime validation, with unavailable paths explained.
- [x] User-facing behavior and operational changes are documented.
- [x] New, moved, renamed, or deleted Swift files are reflected in Xcode groups, target membership, and build phases. (No file membership changes.)
- [x] No credentials, provisioning profiles, personal signing values, or local build artifacts are included.
- [x] Guest VM scripts and VM Asset build tooling remain in `Afcoo/ThruRNDIS_VM_Assets`.
